### PR TITLE
👷 #9: Build binaries on tags

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,11 +4,14 @@ on:
   workflow_call:
 
   push:
-    branches: ["main", "develop"]
-    tags:
-      - "*"
+    branches:
+      - "main"
+      - "develop"
+
   pull_request:
-    branches: ["main", "develop"]
+    branches:
+    - "main"
+    - "develop"
 
 jobs:
   lint:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,6 +3,8 @@ name: lint
 on:
   push:
     branches: ["main", "develop"]
+    tags:
+      - "*"
   pull_request:
     branches: ["main", "develop"]
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,8 @@
 name: lint
 
 on:
+  workflow_call:
+
   push:
     branches: ["main", "develop"]
     tags:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows:
       - lint
-      - security
+      - vuln
 # TODO: uncomment the lines below after tests
 #    branches:
 #      - main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,14 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: build_time
-        run: echo 'BUILD_TIME=date -u +"%Y-%m-%dT%H:%M:%SZ"' >> "$GITHUB_OUTPUT"
+        run: echo 'BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")' >> "$GITHUB_OUTPUT"
 # TODO: uncomment after tests
 #  lint:
 #    uses: ./.github/workflows/lint.yaml
 #  vuln:
 #    uses: ./.github/workflows/vuln.yaml
   release:
-#    needs:
+    needs:
+      - build_time
 #      - lint
 #      - vuln
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: build ${{ matrix.image }} image
         working-directory: ./images
         env:
-          BUILD_TIME: ${{needs.build_time.outputs.build_time}}
+          BUILD_TIME: ${{needs.build_time.outputs.BUILD_TIME}}
         run: VERSION=${{ github.ref_name }} COMMIT=$(git rev-parse --short "$GITHUB_SHA") BUILD_DATE="$BUILD_TIME" make ${{ matrix.image }}
 
       - name: publish ${{ matrix.image }} image to Github Container Registry

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,4 +38,4 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,9 +4,9 @@ on:
   push:
     tags:
       - "*"
-# TODO: uncomment the lines below after tests
-#    branches:
-#      - main
+
+    branches:
+      - main
 
 permissions:
   contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,13 @@ permissions:
   packages: write
 
 jobs:
+  build_time:
+    outputs:
+      BUILD_TIME: ${{ steps.build_time.outputs.BUILD_TIME }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: build_time
+        run: echo 'BUILD_TIME=date -u +"%Y-%m-%dT%H:%M:%SZ"' >> "$GITHUB_OUTPUT"
 # TODO: uncomment after tests
 #  lint:
 #    uses: ./.github/workflows/lint.yaml
@@ -64,7 +71,9 @@ jobs:
 
       - name: build ${{ matrix.image }} image
         working-directory: ./images
-        run: VERSION=${{ github.ref_name }} COMMIT=$(git rev-parse --short "$GITHUB_SHA") BUILD_DATE="$(date --rfc-3339=date)" make ${{ matrix.image }}
+        env:
+          BUILD_TIME: ${{needs.build_time.outputs.build_time}}
+        run: VERSION=${{ github.ref_name }} COMMIT=$(git rev-parse --short "$GITHUB_SHA") BUILD_DATE="$BUILD_TIME" make ${{ matrix.image }}
 
       - name: publish ${{ matrix.image }} image to Github Container Registry
         working-directory: ./images

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,9 @@ jobs:
   vuln:
     uses: ./.github/workflows/vuln.yaml
   release:
-    needs: [lint, vuln]
+    needs:
+      - lint
+      - vuln
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
@@ -39,3 +41,28 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  images:
+    strategy:
+      matrix:
+        image:
+          - alpine
+          - ubuntu
+          - distroless
+          - redhat
+    runs-on: ubuntu-latest
+    needs:
+      - release
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: login into Github Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+
+      - name: build ${{ matrix.image }} image
+        run: VERSION=${{ github.ref_name }} COMMIT=$(git rev-parse --short "$GITHUB_SHA") BUILD_DATE="$(date --rfc-3339=date)" make ${{ matrix.image }}
+
+      - name: publish ${{ matrix.image }} image to Github Container Registry
+        run: VERSION=${{ github.ref_name }} make publish-ghcr-${{ matrix.image }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,8 +58,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: login into Github Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+#      - name: login into Github Container Registry
+#        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
       - name: build ${{ matrix.image }} image
         run: VERSION=${{ github.ref_name }} COMMIT=$(git rev-parse --short "$GITHUB_SHA") BUILD_DATE="$(date --rfc-3339=date)" make ${{ matrix.image }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,15 +13,14 @@ permissions:
   packages: write
 
 jobs:
-# TODO: uncomment after tests
-#  lint:
-#    uses: ./.github/workflows/lint.yaml
-#  vuln:
-#    uses: ./.github/workflows/vuln.yaml
+  lint:
+    uses: ./.github/workflows/lint.yaml
+  vuln:
+    uses: ./.github/workflows/vuln.yaml
   release:
-#    needs:
-#      - lint
-#      - vuln
+    needs:
+      - lint
+      - vuln
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
@@ -34,14 +33,14 @@ jobs:
         with:
           fetch-depth: 0
 
-#      - name: Run GoReleaser
-#        uses: goreleaser/goreleaser-action@v5
-#        with:
-#          distribution: goreleaser
-#          version: latest
-#          args: release --clean
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   images:
     strategy:
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,7 @@ jobs:
 #  vuln:
 #    uses: ./.github/workflows/vuln.yaml
   release:
-    needs:
-      - build_time
+#    needs:
 #      - lint
 #      - vuln
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,21 @@
 name: release
 
 on:
+  workflow_run:
+    workflows:
+      - lint
+      - security
+# TODO: uncomment the lines below after tests
+#    branches:
+#      - main
+    types:
+      - completed
   push:
     tags:
       - '*'
-    branches:
-      - main
+# TODO: uncomment the lines below after tests
+#    branches:
+#      - main
 
 permissions:
   contents: write
@@ -13,6 +23,7 @@ permissions:
 
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,8 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
+          DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
   images:
     strategy:
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,14 +34,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
-        with:
-          distribution: goreleaser
-          version: latest
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Run GoReleaser
+#        uses: goreleaser/goreleaser-action@v5
+#        with:
+#          distribution: goreleaser
+#          version: latest
+#          args: release --clean
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   images:
     strategy:
       matrix:
@@ -61,6 +61,9 @@ jobs:
 # TODO: uncomment after tests
 #      - name: login into Github Container Registry
 #        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+
+      - name: go to images
+        run: cd images
 
       - name: build ${{ matrix.image }} image
         run: VERSION=${{ github.ref_name }} COMMIT=$(git rev-parse --short "$GITHUB_SHA") BUILD_DATE="$(date --rfc-3339=date)" make ${{ matrix.image }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
           DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
+          BREW_TAP_PRIVATE_KEY: ${{ secrets.BREW_TAP_PRIVATE_KEY }}
   images:
     strategy:
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,34 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,11 +62,10 @@ jobs:
 #      - name: login into Github Container Registry
 #        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
-      - name: go to images
-        run: cd images
-
       - name: build ${{ matrix.image }} image
+        working-directory: ./images
         run: VERSION=${{ github.ref_name }} COMMIT=$(git rev-parse --short "$GITHUB_SHA") BUILD_DATE="$(date --rfc-3339=date)" make ${{ matrix.image }}
 
       - name: publish ${{ matrix.image }} image to Github Container Registry
+        working-directory: ./images
         run: VERSION=${{ github.ref_name }} make publish-ghcr-${{ matrix.image }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,26 +1,24 @@
 name: release
 
 on:
-  workflow_run:
-    workflows:
-      - lint
-      - vuln
+  push:
+    tags:
+      - "*"
 # TODO: uncomment the lines below after tests
 #    branches:
 #      - main
-    types:
-      - completed
 
 permissions:
   contents: write
   packages: write
 
 jobs:
+  lint:
+    uses: ./.github/workflows/lint.yaml
+  vuln:
+    uses: ./.github/workflows/vuln.yaml
   release:
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      startsWith(github.event.workflow_run.head_branch, 'refs/tags/')
+    needs: [lint, vuln]
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,14 +13,15 @@ permissions:
   packages: write
 
 jobs:
-  lint:
-    uses: ./.github/workflows/lint.yaml
-  vuln:
-    uses: ./.github/workflows/vuln.yaml
+# TODO: uncomment after tests
+#  lint:
+#    uses: ./.github/workflows/lint.yaml
+#  vuln:
+#    uses: ./.github/workflows/vuln.yaml
   release:
-    needs:
-      - lint
-      - vuln
+#    needs:
+#      - lint
+#      - vuln
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
@@ -57,7 +58,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
+# TODO: uncomment after tests
 #      - name: login into Github Container Registry
 #        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,12 +10,6 @@ on:
 #      - main
     types:
       - completed
-  push:
-    tags:
-      - '*'
-# TODO: uncomment the lines below after tests
-#    branches:
-#      - main
 
 permissions:
   contents: write
@@ -23,7 +17,10 @@ permissions:
 
 jobs:
   release:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      startsWith(github.event.workflow_run.head_branch, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: build_time
-        run: echo 'BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")' >> "$GITHUB_OUTPUT"
+        run: echo "BUILD_TIME=$(date --rfc-3339=seconds)" >> $GITHUB_OUTPUT
 # TODO: uncomment after tests
 #  lint:
 #    uses: ./.github/workflows/lint.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,13 +13,6 @@ permissions:
   packages: write
 
 jobs:
-  build_time:
-    outputs:
-      BUILD_TIME: ${{ steps.build_time.outputs.BUILD_TIME }}
-    runs-on: ubuntu-latest
-    steps:
-      - id: build_time
-        run: echo "BUILD_TIME=$(date --rfc-3339=seconds)" >> $GITHUB_OUTPUT
 # TODO: uncomment after tests
 #  lint:
 #    uses: ./.github/workflows/lint.yaml
@@ -66,15 +59,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-# TODO: uncomment after tests
-#      - name: login into Github Container Registry
-#        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+
+      - name: login into Github Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
       - name: build ${{ matrix.image }} image
         working-directory: ./images
         env:
           BUILD_TIME: ${{needs.build_time.outputs.BUILD_TIME}}
-        run: VERSION=${{ github.ref_name }} COMMIT=$(git rev-parse --short "$GITHUB_SHA") BUILD_DATE="$BUILD_TIME" make ${{ matrix.image }}
+        run: VERSION=${{ github.ref_name }} COMMIT=$(git rev-parse --short "$GITHUB_SHA") make ${{ matrix.image }}
 
       - name: publish ${{ matrix.image }} image to Github Container Registry
         working-directory: ./images

--- a/.github/workflows/vuln.yaml
+++ b/.github/workflows/vuln.yaml
@@ -1,8 +1,8 @@
-name: security
+name: vuln
 
 on:
   push:
-    branches:  ["main", "develop", ]
+    branches:  ["main", "develop"]
     tags:
       - "*"
 

--- a/.github/workflows/vuln.yaml
+++ b/.github/workflows/vuln.yaml
@@ -2,7 +2,9 @@ name: security
 
 on:
   push:
-    branches: [main, develop]
+    branches:  ["main", "develop", ]
+    tags:
+      - "*"
 
   pull_request:
     branches: [main, develop]

--- a/.github/workflows/vuln.yaml
+++ b/.github/workflows/vuln.yaml
@@ -4,12 +4,14 @@ on:
   workflow_call:
 
   push:
-    branches:  ["main", "develop"]
-    tags:
-      - "*"
+    branches:
+      - "main"
+      - "develop"
 
   pull_request:
-    branches: [main, develop]
+    branches:
+      - "main"
+      - "develop"
 
   schedule:
     - cron: '0 10 * * 1' # run "At 10:00 on Monday"

--- a/.github/workflows/vuln.yaml
+++ b/.github/workflows/vuln.yaml
@@ -1,6 +1,8 @@
 name: vuln
 
 on:
+  workflow_call:
+
   push:
     branches:  ["main", "develop"]
     tags:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,98 +58,82 @@ checksum:
   name_template: "{{ .ProjectName }}_v{{ .Version }}_checksums.txt"
 
 release:
-    # Repo in which the release will be created.
-    # Default is extracted from the origin remote URL or empty if its private hosted.
-    github:
-      owner: EinStack
-      name: glide
+  # Repo in which the release will be created.
+  # Default is extracted from the origin remote URL or empty if its private hosted.
+  github:
+    owner: EinStack
+    name: glide
 
-    # If set to true, will not auto-publish the release.
-    # Available only for GitHub and Gitea.
-    draft: true
+  # If set to true, will not auto-publish the release.
+  # Available only for GitHub and Gitea.
+  draft: true
 
-    # Whether to remove existing draft releases with the same name before creating
-    # a new one.
-    # Only effective if `draft` is set to true.
-    # Available only for GitHub.
-    #
-    # Since: v1.11
-    replace_existing_draft: true
+  # Whether to remove existing draft releases with the same name before creating
+  # a new one.
+  # Only effective if `draft` is set to true.
+  # Available only for GitHub.
+  #
+  # Since: v1.11
+  replace_existing_draft: true
 
-    # Useful if you want to delay the creation of the tag in the remote.
-    # You can create the tag locally, but not push it, and run GoReleaser.
-    # It'll then set the `target_commitish` portion of the GitHub release to the
-    # value of this field.
-    # Only works on GitHub.
-    #
-    # Default: ''
-    # Since: v1.11
-    # Templates: allowed
-    target_commitish: "{{ .Commit }}"
+  # Useful if you want to delay the creation of the tag in the remote.
+  # You can create the tag locally, but not push it, and run GoReleaser.
+  # It'll then set the `target_commitish` portion of the GitHub release to the
+  # value of this field.
+  # Only works on GitHub.
+  #
+  # Default: ''
+  # Since: v1.11
+  # Templates: allowed
+  target_commitish: "{{ .Commit }}"
 
-    # If set, will create a release discussion in the category specified.
-    #
-    # Warning: do not use categories in the 'Announcement' format.
-    #  Check https://github.com/goreleaser/goreleaser/issues/2304 for more info.
-    #
-    # Default is empty.
-    discussion_category_name: General
+  # If set, will create a release discussion in the category specified.
+  #
+  # Warning: do not use categories in the 'Announcement' format.
+  #  Check https://github.com/goreleaser/goreleaser/issues/2304 for more info.
+  #
+  # Default is empty.
+  discussion_category_name: General
 
-    # If set to auto, will mark the release as not ready for production
-    # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
-    # If set to true, will mark the release as not ready for production.
-    # Default is false.
-    prerelease: auto
+  # If set to auto, will mark the release as not ready for production
+  # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
+  # If set to true, will mark the release as not ready for production.
+  # Default is false.
+  prerelease: auto
 
-    # If set to false, will NOT mark the release as "latest".
-    # This prevents it from being shown at the top of the release list,
-    # and from being returned when calling https://api.github.com/repos/OWNER/REPO/releases/latest.
-    #
-    # Available only for GitHub.
-    #
-    # Default is true.
-    # Since: v1.20
-    make_latest: true
+  # If set to false, will NOT mark the release as "latest".
+  # This prevents it from being shown at the top of the release list,
+  # and from being returned when calling https://api.github.com/repos/OWNER/REPO/releases/latest.
+  #
+  # Available only for GitHub.
+  #
+  # Default is true.
+  # Since: v1.20
+  make_latest: true
 
-    # What to do with the release notes in case there the release already exists.
-    #
-    # Valid options are:
-    # - `keep-existing`: keep the existing notes
-    # - `append`: append the current release notes to the existing notes
-    # - `prepend`: prepend the current release notes to the existing notes
-    # - `replace`: replace existing notes
-    #
-    # Default is `keep-existing`.
-    mode: append
+  # What to do with the release notes in case there the release already exists.
+  #
+  # Valid options are:
+  # - `keep-existing`: keep the existing notes
+  # - `append`: append the current release notes to the existing notes
+  # - `prepend`: prepend the current release notes to the existing notes
+  # - `replace`: replace existing notes
+  #
+  # Default is `keep-existing`.
+  mode: append
 
-    # Header for the release body.
-    #
-    # Templates: allowed
-#    header: |
-#      ## Some title ({{ .Date }})
-#
-#      Welcome to this new release!
+  # You can change the name of the release.
+  #
+  # Default: '{{.Tag}}' ('{{.PrefixedTag}}' on Pro)
+  # Templates: allowed
+  name_template: "v{{.Version}}"
 
-    # Footer for the release body.
-    #
-    # Templates: allowed
-#    footer: |
-#      ## Thanks
-#
-#      Those were the changes on {{ .Tag }}!
-
-    # You can change the name of the release.
-    #
-    # Default: '{{.Tag}}' ('{{.PrefixedTag}}' on Pro)
-    # Templates: allowed
-    name_template: "v{{.Version}}"
-
-    # You can disable this pipe in order to not create the release on any SCM.
-    # Keep in mind that this might also break things that depend on the release
-    # URL, for instance, homebrew taps.
-    #
-    # Templates: allowed (since v1.15)
-    disable: true
+  # You can disable this pipe in order to not create the release on any SCM.
+  # Keep in mind that this might also break things that depend on the release
+  # URL, for instance, homebrew taps.
+  #
+  # Templates: allowed (since v1.15)
+  disable: true
 
 announce:
   discord:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -114,6 +114,135 @@ release:
   # Templates: allowed
   name_template: "v{{.Version}}"
 
+brews:
+  -
+    # Name of the recipe
+    #
+    # Default: ProjectName
+    # Templates: allowed
+    name: glide
+
+    # Alternative names for the current recipe.
+    #
+    # Useful if you want to publish a versioned formula as well, so users can
+    # more easily downgrade.
+    #
+    # Since: v1.20 (pro)
+    # Templates: allowed
+    alternative_names:
+      - myproject@{{ .Version }}
+      - myproject@{{ .Major }}
+      - myproject@{{ .Major }}{{ .Minor }}
+
+    # GOARM to specify which 32-bit arm version to use if there are multiple
+    # versions from the build section. Brew formulas support only one 32-bit
+    # version.
+    #
+    # Default: 6
+    goarm: 6
+
+    # GOAMD64 to specify which amd64 version to use if there are multiple
+    # versions from the build section.
+    #
+    # Default: v1
+    goamd64: v1
+
+    # NOTE: make sure the url_template, the token and given repo (github or
+    # gitlab) owner and name are from the same kind.
+    # We will probably unify this in the next major version like it is
+    # done with scoop.
+
+    # URL which is determined by the given Token (github, gitlab or gitea).
+    #
+    # Default depends on the client.
+    # Templates: allowed
+    url_template: "https://github.mycompany.com/foo/bar/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+
+    # Allows you to set a custom download strategy. Note that you'll need
+    # to implement the strategy and add it to your tap repository.
+    # Example: https://docs.brew.sh/Formula-Cookbook#specifying-the-download-strategy-explicitly
+    download_strategy: CurlDownloadStrategy
+
+    # Git author used to commit to the repository.
+    commit_author:
+      name: Release Bot
+      email: roman.glushko.m@gmail.com
+
+    # The project name and current git tag are used in the format string.
+    #
+    # Templates: allowed
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+
+    # Folder inside the repository to put the formula.
+    folder: Formula
+
+    # Caveats for the user of your binary.
+    caveats: "How to use this binary"
+
+    # Your app's homepage.
+    homepage: "https://github.com/EinStack/glide"
+
+    # Your app's description.
+    #
+    # Templates: allowed
+    description: "A Lightweight, Cloud-Native LLM Gateway"
+
+    # SPDX identifier of your app's license.
+    license: "Apache-2.0"
+
+    # Setting this will prevent goreleaser to actually try to commit the updated
+    # formula - instead, the formula file will be stored on the dist folder only,
+    # leaving the responsibility of publishing it to the user.
+    # If set to auto, the release will not be uploaded to the homebrew tap
+    # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
+    #
+    # Templates: allowed
+    skip_upload: auto
+
+    # Custom block for brew.
+    # Can be used to specify alternate downloads for devel or head releases.
+    custom_block: |
+      head "https://github.com/some/package.git"
+      ...
+
+    # Packages your package depends on.
+    dependencies: []
+
+    # Repository to push the generated files to.
+    repository:
+      # Repository owner.
+      #
+      # Templates: allowed
+      owner: EinStack
+
+      # Repository name.
+      #
+      # Templates: allowed
+      name: homebrew-tap
+
+      # Optionally a branch can be provided.
+      #
+      # Default: default repository branch
+      # Templates: allowed
+      branch: main
+
+      # Optionally a token can be provided, if it differs from the token
+      # provided to GoReleaser
+      # Templates: allowed
+      token: "{{ .Env.BREW_TAP_TOKEN }}"
+
+      # Clone, create the file, commit and push, to a regular Git repository.
+      #
+      # Notice that this will only have any effect if the given URL is not
+      # empty.
+      #
+      # Since: v1.18
+      git:
+        # The Git URL to push.
+        #
+        # Templates: allowed
+        url: 'git@github.com:EinStack/homebrew-tap.git'
+
 announce:
   discord:
     # Whether its enabled or not.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,7 +22,6 @@ builds:
       - arm
       - arm64
       - ppc64le
-      - s390x
       - riscv64
     goarm:
       - '7'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -177,7 +177,7 @@ brews:
     folder: Formula
 
     # Caveats for the user of your binary.
-    caveats: "How to use this binary"
+    caveats: ""
 
     # Your app's homepage.
     homepage: "https://github.com/EinStack/glide"
@@ -226,11 +226,6 @@ brews:
       # Templates: allowed
       branch: main
 
-      # Optionally a token can be provided, if it differs from the token
-      # provided to GoReleaser
-      # Templates: allowed
-      token: "{{ .Env.BREW_TAP_TOKEN }}"
-
       # Clone, create the file, commit and push, to a regular Git repository.
       #
       # Notice that this will only have any effect if the given URL is not
@@ -242,6 +237,8 @@ brews:
         #
         # Templates: allowed
         url: 'git@github.com:EinStack/homebrew-tap.git'
+
+        private_key: '{{ .Env.BREW_TAP_PRIVATE_KEY }}'
 
 announce:
   discord:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -79,7 +79,7 @@ release:
   #  Check https://github.com/goreleaser/goreleaser/issues/2304 for more info.
   #
   # Default is empty.
-  discussion_category_name: General
+  discussion_category_name: Releases
 
   # If set to auto, will mark the release as not ready for production
   # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
@@ -114,23 +114,22 @@ release:
   # Templates: allowed
   name_template: "v{{.Version}}"
 
-# TODO: uncomment the lines below after tests
-#announce:
-#  discord:
-#    # Whether its enabled or not.
-#    enabled: true
-#
-#    # Message template to use while publishing.
-#    #
-#    # Templates: allowed
-#    message_template: '📦 Glide {{.Tag}} is out! Check it out at {{ .ReleaseURL }}'
-#
-#    # Set author of the embed.
-#    author: 'EinStack'
-#
-#    # Color code of the embed. You have to use decimal numeral system, not hexadecimal.
-#    # Default: '3888754' (the grey-ish from GoReleaser)
-#    color: ''
-#
-#    # URL to an image to use as the icon for the embed.
-#    icon_url: ''
+announce:
+  discord:
+    # Whether its enabled or not.
+    enabled: true
+
+    # Message template to use while publishing.
+    #
+    # Templates: allowed
+    message_template: '📦 Glide {{.Tag}} is out! Check it out at {{ .ReleaseURL }}'
+
+    # Set author of the embed.
+    author: 'EinStack'
+
+    # Color code of the embed. You have to use decimal numeral system, not hexadecimal.
+    # Default: '3888754' (the grey-ish from GoReleaser)
+    color: ''
+
+    # URL to an image to use as the icon for the embed.
+    icon_url: ''

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,6 @@ builds:
       - darwin
       - windows
       - freebsd
-      - openbsd
     goarch:
       - amd64
       - arm

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,6 +40,8 @@ builds:
         goarch: arm64
       - goos: windows
         goarch: arm
+      - goos: linux
+        goarch: arm
 
 changelog:
   skip: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,6 @@ builds:
       - '386'
       - arm
       - arm64
-      - ppc64le
       - riscv64
     goarm:
       - '7'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,6 @@ builds:
       - '386'
       - arm
       - arm64
-      - riscv64
     goarm:
       - '7'
       - '6'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,6 +34,8 @@ builds:
         goarch: arm64
       - goos: windows
         goarch: arm
+      - goos: windows
+        goarch: arm64
       - goos: linux
         goarch: arm
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w -X glide/pkg.version={{.Version}} -X glide/pkg.commitSha={{.ShortCommit}} -X glide/pkg.buildDate={{.Date}}
+      - -s -w -X glide/pkg.version={{.Tag}} -X glide/pkg.commitSha={{.ShortCommit}} -X glide/pkg.buildDate={{.Date}}
     goos:
       - linux
       - darwin
@@ -46,7 +46,7 @@ changelog:
 
 archives:
   - id: glide
-    name_template: '{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    name_template: '{{ .ProjectName }}_v{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     format: tar.gz
     format_overrides:
       - goos: windows
@@ -58,4 +58,115 @@ checksum:
   name_template: "{{ .ProjectName }}_v{{ .Version }}_checksums.txt"
 
 release:
-  disable: true
+    # Repo in which the release will be created.
+    # Default is extracted from the origin remote URL or empty if its private hosted.
+    github:
+      owner: EinStack
+      name: glide
+
+    # If set to true, will not auto-publish the release.
+    # Available only for GitHub and Gitea.
+    draft: true
+
+    # Whether to remove existing draft releases with the same name before creating
+    # a new one.
+    # Only effective if `draft` is set to true.
+    # Available only for GitHub.
+    #
+    # Since: v1.11
+    replace_existing_draft: true
+
+    # Useful if you want to delay the creation of the tag in the remote.
+    # You can create the tag locally, but not push it, and run GoReleaser.
+    # It'll then set the `target_commitish` portion of the GitHub release to the
+    # value of this field.
+    # Only works on GitHub.
+    #
+    # Default: ''
+    # Since: v1.11
+    # Templates: allowed
+    target_commitish: "{{ .Commit }}"
+
+    # If set, will create a release discussion in the category specified.
+    #
+    # Warning: do not use categories in the 'Announcement' format.
+    #  Check https://github.com/goreleaser/goreleaser/issues/2304 for more info.
+    #
+    # Default is empty.
+    discussion_category_name: General
+
+    # If set to auto, will mark the release as not ready for production
+    # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
+    # If set to true, will mark the release as not ready for production.
+    # Default is false.
+    prerelease: auto
+
+    # If set to false, will NOT mark the release as "latest".
+    # This prevents it from being shown at the top of the release list,
+    # and from being returned when calling https://api.github.com/repos/OWNER/REPO/releases/latest.
+    #
+    # Available only for GitHub.
+    #
+    # Default is true.
+    # Since: v1.20
+    make_latest: true
+
+    # What to do with the release notes in case there the release already exists.
+    #
+    # Valid options are:
+    # - `keep-existing`: keep the existing notes
+    # - `append`: append the current release notes to the existing notes
+    # - `prepend`: prepend the current release notes to the existing notes
+    # - `replace`: replace existing notes
+    #
+    # Default is `keep-existing`.
+    mode: append
+
+    # Header for the release body.
+    #
+    # Templates: allowed
+#    header: |
+#      ## Some title ({{ .Date }})
+#
+#      Welcome to this new release!
+
+    # Footer for the release body.
+    #
+    # Templates: allowed
+#    footer: |
+#      ## Thanks
+#
+#      Those were the changes on {{ .Tag }}!
+
+    # You can change the name of the release.
+    #
+    # Default: '{{.Tag}}' ('{{.PrefixedTag}}' on Pro)
+    # Templates: allowed
+    name_template: "v{{.Version}}"
+
+    # You can disable this pipe in order to not create the release on any SCM.
+    # Keep in mind that this might also break things that depend on the release
+    # URL, for instance, homebrew taps.
+    #
+    # Templates: allowed (since v1.15)
+    disable: true
+
+announce:
+  discord:
+    # Whether its enabled or not.
+    enabled: true
+
+    # Message template to use while publishing.
+    #
+    # Templates: allowed
+    message_template: '📦 Glide {{.Tag}} is out! Check it out at {{ .ReleaseURL }}'
+
+    # Set author of the embed.
+    author: 'EinStack'
+
+    # Color code of the embed. You have to use decimal numeral system, not hexadecimal.
+    # Default: '3888754' (the grey-ish from GoReleaser)
+    color: ''
+
+    # URL to an image to use as the icon for the embed.
+    icon_url: ''

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,6 @@ builds:
     goos:
       - linux
       - darwin
-      - windows
       - freebsd
     goarch:
       - amd64
@@ -30,10 +29,6 @@ builds:
       - goos: freebsd
         goarch: arm
       - goos: freebsd
-        goarch: arm64
-      - goos: windows
-        goarch: arm
-      - goos: windows
         goarch: arm64
       - goos: linux
         goarch: arm

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -135,22 +135,23 @@ release:
   # Templates: allowed (since v1.15)
   disable: true
 
-announce:
-  discord:
-    # Whether its enabled or not.
-    enabled: true
-
-    # Message template to use while publishing.
-    #
-    # Templates: allowed
-    message_template: '📦 Glide {{.Tag}} is out! Check it out at {{ .ReleaseURL }}'
-
-    # Set author of the embed.
-    author: 'EinStack'
-
-    # Color code of the embed. You have to use decimal numeral system, not hexadecimal.
-    # Default: '3888754' (the grey-ish from GoReleaser)
-    color: ''
-
-    # URL to an image to use as the icon for the embed.
-    icon_url: ''
+# TODO: uncomment the lines below after tests
+#announce:
+#  discord:
+#    # Whether its enabled or not.
+#    enabled: true
+#
+#    # Message template to use while publishing.
+#    #
+#    # Templates: allowed
+#    message_template: '📦 Glide {{.Tag}} is out! Check it out at {{ .ReleaseURL }}'
+#
+#    # Set author of the embed.
+#    author: 'EinStack'
+#
+#    # Color code of the embed. You have to use decimal numeral system, not hexadecimal.
+#    # Default: '3888754' (the grey-ish from GoReleaser)
+#    color: ''
+#
+#    # URL to an image to use as the icon for the embed.
+#    icon_url: ''

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,6 +42,8 @@ builds:
         goarch: arm
       - goos: linux
         goarch: arm
+      - goos: linux
+        goarch: '386'
 
 changelog:
   skip: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,12 +50,6 @@ checksum:
   name_template: "{{ .ProjectName }}_v{{ .Version }}_checksums.txt"
 
 release:
-  # Repo in which the release will be created.
-  # Default is extracted from the origin remote URL or empty if its private hosted.
-  github:
-    owner: EinStack
-    name: glide
-
   # If set to true, will not auto-publish the release.
   # Available only for GitHub and Gitea.
   draft: true
@@ -119,13 +113,6 @@ release:
   # Default: '{{.Tag}}' ('{{.PrefixedTag}}' on Pro)
   # Templates: allowed
   name_template: "v{{.Version}}"
-
-  # You can disable this pipe in order to not create the release on any SCM.
-  # Keep in mind that this might also break things that depend on the release
-  # URL, for instance, homebrew taps.
-  #
-  # Templates: allowed (since v1.15)
-  disable: true
 
 # TODO: uncomment the lines below after tests
 #announce:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,15 +18,12 @@ builds:
       - openbsd
     goarch:
       - amd64
-      - '386'
       - arm
       - arm64
     goarm:
       - '7'
       - '6'
     ignore:
-      - goos: darwin
-        goarch: '386'
       - goos: openbsd
         goarch: arm
       - goos: openbsd
@@ -39,8 +36,6 @@ builds:
         goarch: arm
       - goos: linux
         goarch: arm
-      - goos: linux
-        goarch: '386'
 
 changelog:
   skip: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,61 @@
+project_name: glide
+
+before:
+  hooks:
+    - go generate
+
+builds:
+  - binary: glide
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X glide/pkg.version={{.Version}} -X glide/pkg.commitSha={{.ShortCommit}} -X glide/pkg.buildDate={{.Date}}
+    goos:
+      - linux
+      - darwin
+      - windows
+      - freebsd
+      - openbsd
+    goarch:
+      - amd64
+      - '386'
+      - arm
+      - arm64
+      - ppc64le
+      - s390x
+      - riscv64
+    goarm:
+      - '7'
+      - '6'
+    ignore:
+      - goos: darwin
+        goarch: '386'
+      - goos: openbsd
+        goarch: arm
+      - goos: openbsd
+        goarch: arm64
+      - goos: freebsd
+        goarch: arm
+      - goos: freebsd
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+
+changelog:
+  skip: true
+
+archives:
+  - id: glide
+    name_template: '{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - LICENSE
+
+checksum:
+  name_template: "{{ .ProjectName }}_v{{ .Version }}_checksums.txt"
+
+release:
+  disable: true

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ vuln: install-checkers ## Check for vulnerabilities
 run: ## Run Glide
 	@go run -ldflags $(LDFLAGS_COMMON) main.go -c ./config.dev.yaml
 
-build: ## Build Glide
+build-bin: ## Build Glide
 	@go build -ldflags $(LDFLAGS_COMMON) -o ./dist/glide
 
 test: ## Run tests

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CHECKER_BIN=$(PWD)/tmp/bin
 VERSION_PACKAGE := glide/pkg
 COMMIT ?= $(shell git describe --dirty --long --always --abbrev=15)
-BUILD_DATE ?= $(shell date +"%Y-%m-%d %H:%M:%S")
+BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 VERSION ?= "latest"
 
 LDFLAGS_COMMON := "-s -w -X $(VERSION_PACKAGE).commitSha=$(COMMIT) -X $(VERSION_PACKAGE).version=$(VERSION) -X $(VERSION_PACKAGE).buildDate=$(BUILD_DATE)"
@@ -39,7 +39,7 @@ vuln: install-checkers ## Check for vulnerabilities
 run: ## Run Glide
 	@go run -ldflags $(LDFLAGS_COMMON) main.go -c ./config.dev.yaml
 
-build-bin: ## Build Glide
+build: ## Build Glide
 	@go build -ldflags $(LDFLAGS_COMMON) -o ./dist/glide
 
 test: ## Run tests

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 CHECKER_BIN=$(PWD)/tmp/bin
 VERSION_PACKAGE := glide/pkg
 COMMIT ?= $(shell git describe --dirty --long --always --abbrev=15)
-VERSION ?= "latest" # TODO: pull/pass a real version
+BUILD_DATE ?= $(shell date +"%Y-%m-%d %H:%M:%S")
+VERSION ?= "latest"
 
-LDFLAGS_COMMON := "-s -w -X $(VERSION_PACKAGE).commitSha=$(COMMIT) -X $(VERSION_PACKAGE).version=$(VERSION)"
+LDFLAGS_COMMON := "-s -w -X $(VERSION_PACKAGE).commitSha=$(COMMIT) -X $(VERSION_PACKAGE).version=$(VERSION) -X $(VERSION_PACKAGE).buildDate=$(BUILD_DATE)"
 
 .PHONY: help
 

--- a/images/Makefile
+++ b/images/Makefile
@@ -1,0 +1,85 @@
+VENDOR ?= "EinStack"
+PROJECT ?= "Glide"
+SOURCE ?= "https://github.com/EinStack/glide"
+LICENSE ?= "Apache-2.0"
+DESCRIPTION ?= "A lightweight, cloud-native LLM gateway"
+REPOSITORY ?= "einstack/glide"
+
+VERSION ?= "dev"
+COMMIT ?= $(shell git describe --dirty --always --abbrev=15)
+BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+
+# OCI Labels: https://specs.opencontainers.org/image-spec/annotations
+
+alpine: ## Make an alpine-based image
+	@echo "🛠️ Build alpine image.."
+	@docker build .. -t $(REPOSITORY):$(VERSION)-alpine -f alpine.Dockerfile \
+	--build-arg VERSION="$(VERSION)" \
+	--build-arg COMMIT="$(COMMIT)" \
+	--build-arg BUILD_DATE="$(BUILD_DATE)" \
+	--label=org.opencontainers.image.vendor="$(VENDOR)" \
+	--label=org.opencontainers.image.title="$(PROJECT)" \
+	--label=org.opencontainers.image.revision="$(COMMIT)" \
+	--label=org.opencontainers.image.version="$(VERSION)" \
+	--label=org.opencontainers.image.created="$(BUILD_DATE)" \
+	--label=org.opencontainers.image.source="$(SOURCE)" \
+	--label=org.opencontainers.image.licenses="$(LICENSE)" \
+	--label=org.opencontainers.image.description=$(DESCRIPTION)
+
+ubuntu: ## Make an ubuntu-based image
+	@echo "🛠️ Build ubuntu image.."
+	@docker build .. -t $(REPOSITORY):$(VERSION)-ubuntu -f ubuntu.Dockerfile \
+	--build-arg VERSION="$(VERSION)" \
+	--build-arg COMMIT="$(COMMIT)" \
+	--build-arg BUILD_DATE="$(BUILD_DATE)" \
+	--label=org.opencontainers.image.vendor=$(VENDOR) \
+	--label=org.opencontainers.image.title=$(PROJECT) \
+	--label=org.opencontainers.image.revision="$(COMMIT)" \
+	--label=org.opencontainers.image.version="$(VERSION)" \
+	--label=org.opencontainers.image.created="$(BUILD_DATE)" \
+	--label=org.opencontainers.image.source=$(SOURCE) \
+	--label=org.opencontainers.image.licenses=$(LICENSE) \
+	--label=org.opencontainers.image.description=$(DESCRIPTION)
+
+distroless: ## Make an distroless-based image
+	@echo "🛠️ Build distroless image.."
+	@docker build .. -t $(REPOSITORY):$(VERSION)-distroless -f distroless.Dockerfile \
+	--build-arg VERSION="$(VERSION)" \
+	--build-arg COMMIT="$(COMMIT)" \
+	--build-arg BUILD_DATE="$(BUILD_DATE)" \
+	--label=org.opencontainers.image.vendor=$(VENDOR) \
+	--label=org.opencontainers.image.title=$(PROJECT) \
+	--label=org.opencontainers.image.revision="$(COMMIT)" \
+	--label=org.opencontainers.image.version="$(VERSION)" \
+	--label=org.opencontainers.image.created="$(BUILD_DATE)" \
+	--label=org.opencontainers.image.source=$(SOURCE) \
+	--label=org.opencontainers.image.licenses=$(LICENSE) \
+	--label=org.opencontainers.image.description=$(DESCRIPTION)
+
+redhat: ## Make an Red Hat-based image
+	@echo "🛠️ Build Red Hat image.."
+	@docker build .. -t $(REPOSITORY):$(VERSION)-redhat -f redhat.Dockerfile \
+	--build-arg VERSION="$(VERSION)" \
+	--build-arg COMMIT="$(COMMIT)" \
+	--build-arg BUILD_DATE="$(BUILD_DATE)" \
+	--label=org.opencontainers.image.vendor=$(VENDOR) \
+	--label=org.opencontainers.image.title=$(PROJECT) \
+	--label=org.opencontainers.image.revision="$(COMMIT)" \
+	--label=org.opencontainers.image.version="$(VERSION)" \
+	--label=org.opencontainers.image.created="$(BUILD_DATE)" \
+	--label=org.opencontainers.image.source=$(SOURCE) \
+	--label=org.opencontainers.image.licenses=$(LICENSE) \
+	--label=org.opencontainers.image.description=$(DESCRIPTION)
+
+publish-ghcr-%: ## Push images to Github Registry
+	@echo "🚚Pushing the $* image to Github Registry.."
+	@docker tag $(REPOSITORY):$(VERSION)-$* ghcr.io/$(REPOSITORY):$(VERSION)-$*
+	@docker tag $(REPOSITORY):$(VERSION)-$* ghcr.io/$(REPOSITORY):latest-$*
+	@docker push ghcr.io/$(REPOSITORY):$(VERSION)-$*
+	@docker push ghcr.io/$(REPOSITORY):latest-$*
+	@ifeq ($*, "alpine") \
+		docker tag $(REPOSITORY):$(VERSION)-$* ghcr.io/$(REPOSITORY):latest \
+		docker push ghcr.io/$(REPOSITORY):latest \
+    endif
+

--- a/images/Makefile
+++ b/images/Makefile
@@ -11,6 +11,7 @@ BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 
 # OCI Labels: https://specs.opencontainers.org/image-spec/annotations
+# Test images via: docker run --rm --platform linux/amd64 -i einstack/glide:dev-alpine --config config.dev.yaml
 
 alpine: ## Make an alpine-based image
 	@echo "🛠️ Build alpine image.."
@@ -71,6 +72,8 @@ redhat: ## Make an Red Hat-based image
 	--label=org.opencontainers.image.source=$(SOURCE) \
 	--label=org.opencontainers.image.licenses=$(LICENSE) \
 	--label=org.opencontainers.image.description=$(DESCRIPTION)
+
+all: alpine ubuntu distroless redhat
 
 publish-ghcr-%: ## Push images to Github Registry
 	@echo "🚚Pushing the $* image to Github Registry.."

--- a/images/Makefile
+++ b/images/Makefile
@@ -1,11 +1,12 @@
-VENDOR ?= "EinStack"
-PROJECT ?= "Glide"
-SOURCE ?= "https://github.com/EinStack/glide"
-LICENSE ?= "Apache-2.0"
+VENDOR ?= einstack
+PROJECT ?= Glide
+SOURCE ?= https://github.com/EinStack/glide
+LICENSE ?= Apache-2.0
 DESCRIPTION ?= "A lightweight, cloud-native LLM gateway"
-REPOSITORY ?= "einstack/glide"
+REPOSITORY ?= einstack/glide
 
-VERSION ?= "dev"
+VERSION ?= dev
+RC_PART ?= rc
 COMMIT ?= $(shell git describe --dirty --always --abbrev=15)
 BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
@@ -14,7 +15,7 @@ BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 # Test images via: docker run --rm --platform linux/amd64 -i einstack/glide:dev-alpine --config config.dev.yaml
 
 alpine: ## Make an alpine-based image
-	@echo "🛠️ Build alpine image.."
+	@echo "🛠️ Build alpine image ($(VERSION)).."
 	@docker build .. -t $(REPOSITORY):$(VERSION)-alpine -f alpine.Dockerfile \
 	--build-arg VERSION="$(VERSION)" \
 	--build-arg COMMIT="$(COMMIT)" \
@@ -29,7 +30,7 @@ alpine: ## Make an alpine-based image
 	--label=org.opencontainers.image.description=$(DESCRIPTION)
 
 ubuntu: ## Make an ubuntu-based image
-	@echo "🛠️ Build ubuntu image.."
+	@echo "🛠️ Build ubuntu image ($(VERSION)).."
 	@docker build .. -t $(REPOSITORY):$(VERSION)-ubuntu -f ubuntu.Dockerfile \
 	--build-arg VERSION="$(VERSION)" \
 	--build-arg COMMIT="$(COMMIT)" \
@@ -44,7 +45,7 @@ ubuntu: ## Make an ubuntu-based image
 	--label=org.opencontainers.image.description=$(DESCRIPTION)
 
 distroless: ## Make an distroless-based image
-	@echo "🛠️ Build distroless image.."
+	@echo "🛠️ Build distroless image ($(VERSION)).."
 	@docker build .. -t $(REPOSITORY):$(VERSION)-distroless -f distroless.Dockerfile \
 	--build-arg VERSION="$(VERSION)" \
 	--build-arg COMMIT="$(COMMIT)" \
@@ -59,7 +60,7 @@ distroless: ## Make an distroless-based image
 	--label=org.opencontainers.image.description=$(DESCRIPTION)
 
 redhat: ## Make an Red Hat-based image
-	@echo "🛠️ Build Red Hat image.."
+	@echo "🛠️ Build Red Hat image ($(VERSION)).."
 	@docker build .. -t $(REPOSITORY):$(VERSION)-redhat -f redhat.Dockerfile \
 	--build-arg VERSION="$(VERSION)" \
 	--build-arg COMMIT="$(COMMIT)" \
@@ -78,11 +79,15 @@ all: alpine ubuntu distroless redhat
 publish-ghcr-%: ## Push images to Github Registry
 	@echo "🚚Pushing the $* image to Github Registry.."
 	@docker tag $(REPOSITORY):$(VERSION)-$* ghcr.io/$(REPOSITORY):$(VERSION)-$*
-	@docker tag $(REPOSITORY):$(VERSION)-$* ghcr.io/$(REPOSITORY):latest-$*
+	@echo "- pushing ghcr.io/$(REPOSITORY):$(VERSION)-$*"
 	@docker push ghcr.io/$(REPOSITORY):$(VERSION)-$*
-	@docker push ghcr.io/$(REPOSITORY):latest-$*
-	@ifeq ($*, "alpine") \
-		docker tag $(REPOSITORY):$(VERSION)-$* ghcr.io/$(REPOSITORY):latest \
-		docker push ghcr.io/$(REPOSITORY):latest \
-    endif
-
+	@echo $(VERSION) | grep -q $(RC_PART) || { \
+		docker tag $(REPOSITORY):$(VERSION)-$* ghcr.io/$(REPOSITORY):latest-$*; \
+		echo "- pushing ghcr.io/$(REPOSITORY):latest-$*"; \
+		docker push ghcr.io/$(REPOSITORY):latest-$*; \
+		if [ "$*" = "alpine" ]; then \
+			docker tag $(REPOSITORY):$(VERSION)-$* ghcr.io/$(REPOSITORY):latest; \
+			echo "- pushing ghcr.io/$(REPOSITORY):latest"; \
+			docker push ghcr.io/$(REPOSITORY):latest; \
+		fi; \
+	}

--- a/images/Makefile
+++ b/images/Makefile
@@ -16,6 +16,8 @@ BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 alpine: ## Make an alpine-based image
 	@echo "🛠️ Build alpine image ($(VERSION)).."
+	@echo "- Commit: $(COMMIT)"
+	@echo "- Build Date: $(BUILD_DATE)"
 	@docker build .. -t $(REPOSITORY):$(VERSION)-alpine -f alpine.Dockerfile \
 	--build-arg VERSION="$(VERSION)" \
 	--build-arg COMMIT="$(COMMIT)" \
@@ -31,6 +33,8 @@ alpine: ## Make an alpine-based image
 
 ubuntu: ## Make an ubuntu-based image
 	@echo "🛠️ Build ubuntu image ($(VERSION)).."
+	@echo "- Commit: $(COMMIT)"
+	@echo "- Build Date: $(BUILD_DATE)"
 	@docker build .. -t $(REPOSITORY):$(VERSION)-ubuntu -f ubuntu.Dockerfile \
 	--build-arg VERSION="$(VERSION)" \
 	--build-arg COMMIT="$(COMMIT)" \
@@ -46,6 +50,8 @@ ubuntu: ## Make an ubuntu-based image
 
 distroless: ## Make an distroless-based image
 	@echo "🛠️ Build distroless image ($(VERSION)).."
+	@echo "- Commit: $(COMMIT)"
+	@echo "- Build Date: $(BUILD_DATE)"
 	@docker build .. -t $(REPOSITORY):$(VERSION)-distroless -f distroless.Dockerfile \
 	--build-arg VERSION="$(VERSION)" \
 	--build-arg COMMIT="$(COMMIT)" \
@@ -61,6 +67,8 @@ distroless: ## Make an distroless-based image
 
 redhat: ## Make an Red Hat-based image
 	@echo "🛠️ Build Red Hat image ($(VERSION)).."
+	@echo "- Commit: $(COMMIT)"
+	@echo "- Build Date: $(BUILD_DATE)"
 	@docker build .. -t $(REPOSITORY):$(VERSION)-redhat -f redhat.Dockerfile \
 	--build-arg VERSION="$(VERSION)" \
 	--build-arg COMMIT="$(COMMIT)" \

--- a/images/alpine.Dockerfile
+++ b/images/alpine.Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.21-alpine as build
+
+ARG VERSION
+ARG COMMIT
+ARG BUILD_DATE
+
+WORKDIR /build
+
+COPY . /build/
+RUN go mod download
+RUN go build -ldflags "-s -w -X glide/pkg.version=$VERSION -X glide/pkg.commitSha=$COMMIT -X glide/pkg.buildDate=$BUILD_DATE" -o /build/dist/glide
+
+FROM alpine:3.19 as release
+
+WORKDIR /bin
+COPY --from=build /build/glide /bin/
+
+ENTRYPOINT ["/bin/glide"]

--- a/images/alpine.Dockerfile
+++ b/images/alpine.Dockerfile
@@ -5,6 +5,8 @@ ARG VERSION
 ARG COMMIT
 ARG BUILD_DATE
 
+ENV GOOS=linux
+
 WORKDIR /build
 
 COPY . /build/
@@ -14,6 +16,6 @@ RUN go build -ldflags "-s -w -X glide/pkg.version=$VERSION -X glide/pkg.commitSh
 FROM alpine:3.19 as release
 
 WORKDIR /bin
-COPY --from=build /build/glide /bin/
+COPY --from=build /build/dist/glide /bin/
 
 ENTRYPOINT ["/bin/glide"]

--- a/images/distroless.Dockerfile
+++ b/images/distroless.Dockerfile
@@ -5,6 +5,8 @@ ARG VERSION
 ARG COMMIT
 ARG BUILD_DATE
 
+ENV GOOS=linux
+
 WORKDIR /build
 
 COPY . /build/
@@ -14,6 +16,6 @@ RUN go build -ldflags "-s -w -X glide/pkg.version=$VERSION -X glide/pkg.commitSh
 FROM gcr.io/distroless/static-debian12:nonroot as release
 
 WORKDIR /bin
-COPY --from=build /build/glide /bin/
+COPY --from=build /build/dist/glide /bin/
 
 ENTRYPOINT ["/bin/glide"]

--- a/images/distroless.Dockerfile
+++ b/images/distroless.Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.21-alpine as build
+
+ARG VERSION
+ARG COMMIT
+ARG BUILD_DATE
+
+WORKDIR /build
+
+COPY . /build/
+RUN go mod download
+RUN go build -ldflags "-s -w -X glide/pkg.version=$VERSION -X glide/pkg.commitSha=$COMMIT -X glide/pkg.buildDate=$BUILD_DATE" -o /build/dist/glide
+
+FROM gcr.io/distroless/static-debian12:nonroot as release
+
+WORKDIR /bin
+COPY --from=build /build/glide /bin/
+
+ENTRYPOINT ["/bin/glide"]

--- a/images/redhat.Dockerfile
+++ b/images/redhat.Dockerfile
@@ -5,6 +5,8 @@ ARG VERSION
 ARG COMMIT
 ARG BUILD_DATE
 
+ENV GOOS=linux
+
 WORKDIR /build
 
 COPY . /build/
@@ -14,6 +16,6 @@ RUN go build -ldflags "-s -w -X glide/pkg.version=$VERSION -X glide/pkg.commitSh
 FROM redhat/ubi8-micro:8.9 as release
 
 WORKDIR /bin
-COPY --from=build /build/glide /bin/
+COPY --from=build /build/dist/glide /bin/
 
 ENTRYPOINT ["/bin/glide"]

--- a/images/redhat.Dockerfile
+++ b/images/redhat.Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.21-alpine as build
+
+ARG VERSION
+ARG COMMIT
+ARG BUILD_DATE
+
+WORKDIR /build
+
+COPY . /build/
+RUN go mod download
+RUN go build -ldflags "-s -w -X glide/pkg.version=$VERSION -X glide/pkg.commitSha=$COMMIT -X glide/pkg.buildDate=$BUILD_DATE" -o /build/dist/glide
+
+FROM redhat/ubi8-micro:8.9 as release
+
+WORKDIR /bin
+COPY --from=build /build/glide /bin/
+
+ENTRYPOINT ["/bin/glide"]

--- a/images/ubuntu.Dockerfile
+++ b/images/ubuntu.Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.21-alpine as build
+
+ARG VERSION
+ARG COMMIT
+ARG BUILD_DATE
+
+WORKDIR /build
+
+COPY . /build/
+RUN go mod download
+RUN go build -ldflags "-s -w -X glide/pkg.version=$VERSION -X glide/pkg.commitSha=$COMMIT -X glide/pkg.buildDate=$BUILD_DATE" -o /build/dist/glide
+
+FROM ubuntu:22.04 as release
+
+WORKDIR /bin
+COPY --from=build /build/glide /bin/
+
+ENTRYPOINT ["/bin/glide"]

--- a/images/ubuntu.Dockerfile
+++ b/images/ubuntu.Dockerfile
@@ -5,6 +5,8 @@ ARG VERSION
 ARG COMMIT
 ARG BUILD_DATE
 
+ENV GOOS=linux
+
 WORKDIR /build
 
 COPY . /build/
@@ -14,6 +16,6 @@ RUN go build -ldflags "-s -w -X glide/pkg.version=$VERSION -X glide/pkg.commitSh
 FROM ubuntu:22.04 as release
 
 WORKDIR /bin
-COPY --from=build /build/glide /bin/
+COPY --from=build /build/dist/glide /bin/
 
 ENTRYPOINT ["/bin/glide"]

--- a/pkg/routers/health/buckets.go
+++ b/pkg/routers/health/buckets.go
@@ -19,11 +19,11 @@ type TokenBucket struct {
 	timePerBurst uint64
 }
 
-func NewTokenBucket(timePerToken, burstSize uint64) *TokenBucket {
+func NewTokenBucket(timePerToken, burstSize uint) *TokenBucket {
 	return &TokenBucket{
 		timePointer:  0,
-		timePerToken: timePerToken,
-		timePerBurst: burstSize * timePerToken,
+		timePerToken: uint64(timePerToken),
+		timePerBurst: uint64(burstSize * timePerToken),
 	}
 }
 

--- a/pkg/routers/health/buckets_test.go
+++ b/pkg/routers/health/buckets_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestTokenBucket_Take(t *testing.T) {
 	bucketSize := 10
-	bucket := NewTokenBucket(1000, uint64(bucketSize))
+	bucket := NewTokenBucket(1000, uint(bucketSize))
 
 	for i := 0; i < bucketSize-1; i++ {
 		require.NoError(t, bucket.Take(1))

--- a/pkg/routers/health/error_budget.go
+++ b/pkg/routers/health/error_budget.go
@@ -20,11 +20,11 @@ const (
 // ErrorBudget parses human-friendly error budget representation and return it as errors & update rate pair
 // Error budgets could be set as a string in the following format: "10/s", "5/ms", "100/m" "1500/h"
 type ErrorBudget struct {
-	budget int
+	budget uint
 	unit   Unit
 }
 
-func NewErrorBudget(budget int, unit Unit) *ErrorBudget {
+func NewErrorBudget(budget uint, unit Unit) *ErrorBudget {
 	return &ErrorBudget{
 		budget: budget,
 		unit:   unit,
@@ -39,13 +39,13 @@ func DefaultErrorBudget() *ErrorBudget {
 }
 
 // Budget defines max allows number of errors per given time period
-func (b *ErrorBudget) Budget() uint64 {
-	return uint64(b.budget)
+func (b *ErrorBudget) Budget() uint {
+	return b.budget
 }
 
 // TimePerTokenMicro defines how much time do we need to wait to get one error token recovered (in microseconds)
-func (b *ErrorBudget) TimePerTokenMicro() uint64 {
-	return uint64(b.unitToMicro(b.unit) / b.budget)
+func (b *ErrorBudget) TimePerTokenMicro() uint {
+	return b.unitToMicro(b.unit) / b.budget
 }
 
 // MarshalText implements the encoding.TextMarshaler interface.
@@ -76,13 +76,13 @@ func (b *ErrorBudget) UnmarshalText(text []byte) error {
 		return fmt.Errorf("invalid unit (supported: ms, s, m, h)")
 	}
 
-	b.budget = budget
+	b.budget = uint(budget)
 	b.unit = unit
 
 	return nil
 }
 
-func (b *ErrorBudget) unitToMicro(unit Unit) int {
+func (b *ErrorBudget) unitToMicro(unit Unit) uint {
 	switch unit {
 	case MILLI:
 		return 1_000 // 1 ms = 1000 microseconds
@@ -99,5 +99,5 @@ func (b *ErrorBudget) unitToMicro(unit Unit) int {
 
 // String returns the ID string representation as "type[/name]" format.
 func (b *ErrorBudget) String() string {
-	return strconv.Itoa(b.budget) + budgetSeparator + string(b.unit)
+	return strconv.Itoa(int(b.budget)) + budgetSeparator + string(b.unit)
 }

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -13,8 +13,17 @@ var version = "devel"
 // and will be populated by the Makefile
 var commitSha = "unknown"
 
+// buildDate captures the time when the build happened
+var buildDate = "unknown"
+
 var FullVersion string
 
 func init() {
-	FullVersion = fmt.Sprintf("%s (commit: %s, %s)", version, commitSha, runtime.Version())
+	FullVersion = fmt.Sprintf(
+		"%s (commit: %s, runtime: %s, buildDate: %s)",
+		version,
+		commitSha,
+		runtime.Version(),
+		buildDate,
+	)
 }


### PR DESCRIPTION
Implementation of [GEP0004 ](https://github.com/EinStack/geps/pull/7) related to binary & image building workflow.

Changes:
- On tag creation in the main branch, there is a new release workflow that builds and publish binaries and images
- There are four images built for each Glide version with different OS flavours
- Building binaries only for netpoll-compatible OS
- Binaries are attached to a GH release draft
- When the build is done there is an announcement sent to Discord and GH discussions
- Added a basic homebrew tap publishing