### PR TITLE
✨ #81: Allow to chat message based for specific models

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,13 @@ See [API Reference](https://backlandlabs.mintlify.app/api-reference/introduction
 
 ```json
 {
+ "model": "gpt-3.5-turbo", # this is not required but cna be used to specify different prompts to different models
  "message":
       {
         "role": "user",
         "content": "Where was it played?"
       },
-    "messageHistory": [
+  "messageHistory": [
       {"role": "system", "content": "You are a helpful assistant."},
       {"role": "user", "content": "Who won the world series in 2020?"},
       {"role": "assistant", "content": "The Los Angeles Dodgers won the World Series in 2020."}

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ See [API Reference](https://backlandlabs.mintlify.app/api-reference/introduction
 
 ```json
 {
- "model": "gpt-3.5-turbo", # this is not required but cna be used to specify different prompts to different models
+ "model": "gpt-3.5-turbo", # this is not required but can be used to specify different prompts to different models
  "message":
       {
         "role": "user",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -658,6 +658,9 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/schemas.ChatMessage"
                     }
+                },
+                "model": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -616,6 +616,17 @@ const docTemplate = `{
                 }
             }
         },
+        "schemas.OverrideChatRequest": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "$ref": "#/definitions/schemas.ChatMessage"
+                },
+                "model_id": {
+                    "type": "string"
+                }
+            }
+        },
         "schemas.ProviderResponse": {
             "type": "object",
             "properties": {
@@ -659,8 +670,8 @@ const docTemplate = `{
                         "$ref": "#/definitions/schemas.ChatMessage"
                     }
                 },
-                "model": {
-                    "type": "string"
+                "override": {
+                    "$ref": "#/definitions/schemas.OverrideChatRequest"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -613,6 +613,17 @@
                 }
             }
         },
+        "schemas.OverrideChatRequest": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "$ref": "#/definitions/schemas.ChatMessage"
+                },
+                "model_id": {
+                    "type": "string"
+                }
+            }
+        },
         "schemas.ProviderResponse": {
             "type": "object",
             "properties": {
@@ -656,8 +667,8 @@
                         "$ref": "#/definitions/schemas.ChatMessage"
                     }
                 },
-                "model": {
-                    "type": "string"
+                "override": {
+                    "$ref": "#/definitions/schemas.OverrideChatRequest"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -655,6 +655,9 @@
                     "items": {
                         "$ref": "#/definitions/schemas.ChatMessage"
                     }
+                },
+                "model": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -363,6 +363,8 @@ definitions:
         items:
           $ref: '#/definitions/schemas.ChatMessage'
         type: array
+      model:
+        type: string
     type: object
   schemas.UnifiedChatResponse:
     properties:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -335,6 +335,13 @@ definitions:
           or assistant.
         type: string
     type: object
+  schemas.OverrideChatRequest:
+    properties:
+      message:
+        $ref: '#/definitions/schemas.ChatMessage'
+      model_id:
+        type: string
+    type: object
   schemas.ProviderResponse:
     properties:
       message:
@@ -363,8 +370,8 @@ definitions:
         items:
           $ref: '#/definitions/schemas.ChatMessage'
         type: array
-      model:
-        type: string
+      override:
+        $ref: '#/definitions/schemas.OverrideChatRequest'
     type: object
   schemas.UnifiedChatResponse:
     properties:

--- a/pkg/api/http/handlers.go
+++ b/pkg/api/http/handlers.go
@@ -34,7 +34,7 @@ type Handler = func(ctx context.Context, c *app.RequestContext)
 func LangChatHandler(routerManager *routers.RouterManager) Handler {
 	return func(ctx context.Context, c *app.RequestContext) {
 		// Unmarshal request body
-		var req []schemas.UnifiedChatRequest
+		var req *schemas.UnifiedChatRequest
 
 		err := json.Unmarshal(c.Request.Body(), &req)
 		if err != nil {

--- a/pkg/api/http/handlers.go
+++ b/pkg/api/http/handlers.go
@@ -33,10 +33,12 @@ type Handler = func(ctx context.Context, c *app.RequestContext)
 //	@Router			/v1/language/{router}/chat [POST]
 func LangChatHandler(routerManager *routers.RouterManager) Handler {
 	return func(ctx context.Context, c *app.RequestContext) {
-		var req *schemas.UnifiedChatRequest
+		// Unmarshal request body
+		var req []schemas.UnifiedChatRequest
 
 		err := json.Unmarshal(c.Request.Body(), &req)
 		if err != nil {
+			// Return bad request error
 			c.JSON(consts.StatusBadRequest, ErrorSchema{
 				Message: err.Error(),
 			})
@@ -44,8 +46,10 @@ func LangChatHandler(routerManager *routers.RouterManager) Handler {
 			return
 		}
 
+		// Bind JSON to request
 		err = c.BindJSON(&req)
 		if err != nil {
+			// Return bad request error
 			c.JSON(consts.StatusBadRequest, ErrorSchema{
 				Message: err.Error(),
 			})
@@ -53,10 +57,12 @@ func LangChatHandler(routerManager *routers.RouterManager) Handler {
 			return
 		}
 
+		// Get router ID from path
 		routerID := c.Param("router")
 		router, err := routerManager.GetLangRouter(routerID)
 
 		if errors.Is(err, routers.ErrRouterNotFound) {
+			// Return not found error
 			c.JSON(consts.StatusNotFound, ErrorSchema{
 				Message: err.Error(),
 			})
@@ -64,9 +70,10 @@ func LangChatHandler(routerManager *routers.RouterManager) Handler {
 			return
 		}
 
+		// Chat with router
 		resp, err := router.Chat(ctx, req)
 		if err != nil {
-			// TODO: do a better handling, not everything is going to be an internal error
+			// Return internal server error
 			c.JSON(consts.StatusInternalServerError, ErrorSchema{
 				Message: err.Error(),
 			})
@@ -74,6 +81,7 @@ func LangChatHandler(routerManager *routers.RouterManager) Handler {
 			return
 		}
 
+		// Return chat response
 		c.JSON(consts.StatusOK, resp)
 	}
 }

--- a/pkg/api/schemas/language.go
+++ b/pkg/api/schemas/language.go
@@ -2,6 +2,7 @@ package schemas
 
 // UnifiedChatRequest defines Glide's Chat Request Schema unified across all language models
 type UnifiedChatRequest struct {
+	Model          string        `json:"model"`
 	Message        ChatMessage   `json:"message"`
 	MessageHistory []ChatMessage `json:"messageHistory"`
 }

--- a/pkg/api/schemas/language.go
+++ b/pkg/api/schemas/language.go
@@ -2,9 +2,14 @@ package schemas
 
 // UnifiedChatRequest defines Glide's Chat Request Schema unified across all language models
 type UnifiedChatRequest struct {
-	Model          string        `json:"model"`
-	Message        ChatMessage   `json:"message"`
-	MessageHistory []ChatMessage `json:"messageHistory"`
+	Message        ChatMessage         `json:"message"`
+	MessageHistory []ChatMessage       `json:"messageHistory"`
+	Override       OverrideChatRequest `json:"override,omitempty"`
+}
+
+type OverrideChatRequest struct {
+	Model   string      `json:"model_id"`
+	Message ChatMessage `json:"message"`
 }
 
 func NewChatFromStr(message string) *UnifiedChatRequest {

--- a/pkg/routers/router.go
+++ b/pkg/routers/router.go
@@ -127,7 +127,12 @@ func getPayload(request []schemas.UnifiedChatRequest, model string) *schemas.Uni
 
 	for _, req := range request {
 		if req.Model == model {
-			payload = &req
+			newPayload := schemas.UnifiedChatRequest{
+				Model:          req.Model,
+				Message:        req.Message,
+				MessageHistory: req.MessageHistory,
+			}
+			payload = &newPayload
 			modelExists = true
 
 			break
@@ -135,7 +140,12 @@ func getPayload(request []schemas.UnifiedChatRequest, model string) *schemas.Uni
 	}
 
 	if !modelExists {
-		payload = &(request)[0]
+		newPayload := schemas.UnifiedChatRequest{
+			Model:          request[0].Model,
+			Message:        request[0].Message,
+			MessageHistory: request[0].MessageHistory,
+		}
+		payload = &newPayload
 	}
 
 	return payload

--- a/pkg/routers/router.go
+++ b/pkg/routers/router.go
@@ -55,7 +55,7 @@ func (r *LangRouter) ID() string {
 	return r.routerID
 }
 
-func (r *LangRouter) Chat(ctx context.Context, request *schemas.UnifiedChatRequest) (*schemas.UnifiedChatResponse, error) {
+func (r *LangRouter) Chat(ctx context.Context, request []schemas.UnifiedChatRequest) (*schemas.UnifiedChatResponse, error) {
 	if len(r.models) == 0 {
 		return nil, ErrNoModels
 	}
@@ -75,7 +75,20 @@ func (r *LangRouter) Chat(ctx context.Context, request *schemas.UnifiedChatReque
 
 			langModel := model.(providers.LanguageModel)
 
-			resp, err := langModel.Chat(ctx, request)
+			var payload *schemas.UnifiedChatRequest
+
+			if len(request) == 1 {
+				payload = &(request)[0]
+			} else {
+				for _, req := range request {
+					if req.Model == langModel.ID() {
+						payload = &req
+						break
+					}
+				}
+			}
+
+			resp, err := langModel.Chat(ctx, payload)
 			if err != nil {
 				r.telemetry.Logger.Warn(
 					"lang model failed processing chat request",

--- a/pkg/routers/router_test.go
+++ b/pkg/routers/router_test.go
@@ -55,11 +55,9 @@ func TestLangRouter_Priority_PickFistHealthy(t *testing.T) {
 
 	ctx := context.Background()
 	req := schemas.NewChatFromStr("tell me a dad joke")
-	reqs := make([]schemas.UnifiedChatRequest, 0)
-	reqs = append(reqs, *req)
 
 	for i := 0; i < 2; i++ {
-		resp, err := router.Chat(ctx, reqs)
+		resp, err := router.Chat(ctx, req)
 
 		require.Equal(t, "first", resp.ModelID)
 		require.Equal(t, "test_router", resp.RouterID)
@@ -113,11 +111,8 @@ func TestLangRouter_Priority_PickThirdHealthy(t *testing.T) {
 	ctx := context.Background()
 	req := schemas.NewChatFromStr("tell me a dad joke")
 
-	reqs := make([]schemas.UnifiedChatRequest, 0)
-	reqs = append(reqs, *req)
-
 	for _, modelID := range expectedModels {
-		resp, err := router.Chat(ctx, reqs)
+		resp, err := router.Chat(ctx, req)
 
 		require.NoError(t, err)
 		require.Equal(t, modelID, resp.ModelID)
@@ -159,12 +154,7 @@ func TestLangRouter_Priority_SuccessOnRetry(t *testing.T) {
 		telemetry: telemetry.NewTelemetryMock(),
 	}
 
-	req := schemas.NewChatFromStr("tell me a dad joke")
-
-	reqs := make([]schemas.UnifiedChatRequest, 0)
-	reqs = append(reqs, *req)
-
-	resp, err := router.Chat(context.Background(), reqs)
+	resp, err := router.Chat(context.Background(), schemas.NewChatFromStr("tell me a dad joke"))
 
 	require.NoError(t, err)
 	require.Equal(t, "first", resp.ModelID)
@@ -205,13 +195,8 @@ func TestLangRouter_Priority_UnhealthyModelInThePool(t *testing.T) {
 		telemetry: telemetry.NewTelemetryMock(),
 	}
 
-	req := schemas.NewChatFromStr("tell me a dad joke")
-
-	reqs := make([]schemas.UnifiedChatRequest, 0)
-	reqs = append(reqs, *req)
-
 	for i := 0; i < 2; i++ {
-		resp, err := router.Chat(context.Background(), reqs)
+		resp, err := router.Chat(context.Background(), schemas.NewChatFromStr("tell me a dad joke"))
 
 		require.NoError(t, err)
 		require.Equal(t, "second", resp.ModelID)
@@ -253,12 +238,7 @@ func TestLangRouter_Priority_AllModelsUnavailable(t *testing.T) {
 		telemetry: telemetry.NewTelemetryMock(),
 	}
 
-	req := schemas.NewChatFromStr("tell me a dad joke")
-
-	reqs := make([]schemas.UnifiedChatRequest, 0)
-	reqs = append(reqs, *req)
-
-	_, err := router.Chat(context.Background(), reqs)
+	_, err := router.Chat(context.Background(), schemas.NewChatFromStr("tell me a dad joke"))
 
 	require.Error(t, err)
 }

--- a/pkg/routers/router_test.go
+++ b/pkg/routers/router_test.go
@@ -55,9 +55,11 @@ func TestLangRouter_Priority_PickFistHealthy(t *testing.T) {
 
 	ctx := context.Background()
 	req := schemas.NewChatFromStr("tell me a dad joke")
+	reqs := make([]schemas.UnifiedChatRequest, 0)
+	reqs = append(reqs, *req)
 
 	for i := 0; i < 2; i++ {
-		resp, err := router.Chat(ctx, req)
+		resp, err := router.Chat(ctx, reqs)
 
 		require.Equal(t, "first", resp.ModelID)
 		require.Equal(t, "test_router", resp.RouterID)
@@ -111,8 +113,11 @@ func TestLangRouter_Priority_PickThirdHealthy(t *testing.T) {
 	ctx := context.Background()
 	req := schemas.NewChatFromStr("tell me a dad joke")
 
+	reqs := make([]schemas.UnifiedChatRequest, 0)
+	reqs = append(reqs, *req)
+
 	for _, modelID := range expectedModels {
-		resp, err := router.Chat(ctx, req)
+		resp, err := router.Chat(ctx, reqs)
 
 		require.NoError(t, err)
 		require.Equal(t, modelID, resp.ModelID)
@@ -154,7 +159,12 @@ func TestLangRouter_Priority_SuccessOnRetry(t *testing.T) {
 		telemetry: telemetry.NewTelemetryMock(),
 	}
 
-	resp, err := router.Chat(context.Background(), schemas.NewChatFromStr("tell me a dad joke"))
+	req := schemas.NewChatFromStr("tell me a dad joke")
+
+	reqs := make([]schemas.UnifiedChatRequest, 0)
+	reqs = append(reqs, *req)
+
+	resp, err := router.Chat(context.Background(), reqs)
 
 	require.NoError(t, err)
 	require.Equal(t, "first", resp.ModelID)
@@ -195,8 +205,13 @@ func TestLangRouter_Priority_UnhealthyModelInThePool(t *testing.T) {
 		telemetry: telemetry.NewTelemetryMock(),
 	}
 
+	req := schemas.NewChatFromStr("tell me a dad joke")
+
+	reqs := make([]schemas.UnifiedChatRequest, 0)
+	reqs = append(reqs, *req)
+
 	for i := 0; i < 2; i++ {
-		resp, err := router.Chat(context.Background(), schemas.NewChatFromStr("tell me a dad joke"))
+		resp, err := router.Chat(context.Background(), reqs)
 
 		require.NoError(t, err)
 		require.Equal(t, "second", resp.ModelID)
@@ -238,7 +253,12 @@ func TestLangRouter_Priority_AllModelsUnavailable(t *testing.T) {
 		telemetry: telemetry.NewTelemetryMock(),
 	}
 
-	_, err := router.Chat(context.Background(), schemas.NewChatFromStr("tell me a dad joke"))
+	req := schemas.NewChatFromStr("tell me a dad joke")
+
+	reqs := make([]schemas.UnifiedChatRequest, 0)
+	reqs = append(reqs, *req)
+
+	_, err := router.Chat(context.Background(), reqs)
 
 	require.Error(t, err)
 }


### PR DESCRIPTION
Update the Unified Chat Schema to allow model specification. This allows users to specify different prompts for different models. The correct JSON request is selected after the router has determined the correct model.