### PR TITLE
👷 Create a image tag with pure version (without distro suffix)

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -97,6 +97,9 @@ publish-ghcr-%: ## Push images to Github Registry
 			docker tag $(REPOSITORY):$(VERSION)-$* ghcr.io/$(REPOSITORY):latest; \
 			echo "- pushing ghcr.io/$(REPOSITORY):latest"; \
 			docker push ghcr.io/$(REPOSITORY):latest; \
+			docker tag $(REPOSITORY):$(VERSION)-$* ghcr.io/$(REPOSITORY):$(VERSION); \
+			echo "- pushing ghcr.io/$(REPOSITORY):$(VERSION)"; \
+			docker push ghcr.io/$(REPOSITORY):$(VERSION); \
 		fi; \
 	}
 


### PR DESCRIPTION
This is useful for helm charts, so we could use AppVersion param to pull image as default