### PR TITLE
🔧 #161: Refined the chat stream req/responses

### DIFF
--- a/pkg/api/http/handlers.go
+++ b/pkg/api/http/handlers.go
@@ -118,9 +118,8 @@ func LangStreamChatHandler(tel *telemetry.Telemetry, routerManager *routers.Rout
 		// websocket.Conn bindings https://pkg.go.dev/github.com/fasthttp/websocket?tab=doc#pkg-index
 
 		var (
-			err         error
-			chatRequest schemas.ChatRequest
-			wg          sync.WaitGroup
+			err error
+			wg  sync.WaitGroup
 		)
 
 		chunkResultC := make(chan *schemas.ChatStreamResult)
@@ -151,6 +150,8 @@ func LangStreamChatHandler(tel *telemetry.Telemetry, routerManager *routers.Rout
 		}()
 
 		for {
+			var chatRequest schemas.ChatStreamRequest
+
 			if err = c.ReadJSON(&chatRequest); err != nil {
 				if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
 					tel.L().Warn("Streaming Chat connection is closed", zap.Error(err), zap.String("routerID", routerID))
@@ -164,7 +165,7 @@ func LangStreamChatHandler(tel *telemetry.Telemetry, routerManager *routers.Rout
 			// TODO: handle termination gracefully
 			wg.Add(1)
 
-			go func(chatRequest schemas.ChatRequest) {
+			go func(chatRequest schemas.ChatStreamRequest) {
 				defer wg.Done()
 
 				router.ChatStream(context.Background(), &chatRequest, chunkResultC)

--- a/pkg/api/schemas/chat.go
+++ b/pkg/api/schemas/chat.go
@@ -17,7 +17,7 @@ func NewChatFromStr(message string) *ChatRequest {
 		Message: ChatMessage{
 			"human",
 			message,
-			"roma",
+			"glide",
 		},
 	}
 }

--- a/pkg/api/schemas/chat_stream.go
+++ b/pkg/api/schemas/chat_stream.go
@@ -1,29 +1,39 @@
 package schemas
 
-import "time"
+type (
+	Metadata     = map[string]any
+	FinishReason = string
+)
+
+var Complete FinishReason = "complete"
 
 // ChatStreamRequest defines a message that requests a new streaming chat
 type ChatStreamRequest struct {
-	// TODO: implement
+	Message        ChatMessage          `json:"message" validate:"required"`
+	MessageHistory []ChatMessage        `json:"messageHistory" validate:"required"`
+	Override       *OverrideChatRequest `json:"overrideMessage,omitempty"`
+	Metadata       *Metadata            `json:"metadata,omitempty"`
+}
+
+type ModelChunkResponse struct {
+	Metadata     *Metadata     `json:"metadata,omitempty"`
+	Message      ChatMessage   `json:"message"`
+	FinishReason *FinishReason `json:"finishReason,omitempty"`
 }
 
 // ChatStreamChunk defines a message for a chunk of streaming chat response
 type ChatStreamChunk struct {
-	// TODO: modify according to the streaming chat needs
-	ID            string         `json:"id,omitempty"`
-	Created       int            `json:"created,omitempty"`
-	Provider      string         `json:"provider,omitempty"`
-	RouterID      string         `json:"router,omitempty"`
-	ModelID       string         `json:"model_id,omitempty"`
-	ModelName     string         `json:"model,omitempty"`
-	Cached        bool           `json:"cached,omitempty"`
-	ModelResponse ModelResponse  `json:"modelResponse,omitempty"`
-	Latency       *time.Duration `json:"-"`
-	// TODO: add chat request-specific context
+	ID            string             `json:"id,omitempty"`
+	CreatedAt     int                `json:"createdAt,omitempty"`
+	Provider      string             `json:"providerId,omitempty"`
+	RouterID      string             `json:"routerId,omitempty"`
+	ModelID       string             `json:"modelId,omitempty"`
+	Cached        bool               `json:"cached,omitempty"`
+	ModelName     string             `json:"modelName,omitempty"`
+	ModelResponse ModelChunkResponse `json:"modelResponse,omitempty"`
 }
 
 type ChatStreamError struct {
-	// TODO: add chat request-specific context
 	Reason  string `json:"reason"`
 	Message string `json:"message"`
 }

--- a/pkg/api/schemas/chat_stream.go
+++ b/pkg/api/schemas/chat_stream.go
@@ -40,6 +40,7 @@ type ChatStreamChunk struct {
 	ModelID       string             `json:"modelId,omitempty"`
 	Cached        bool               `json:"cached,omitempty"`
 	ModelName     string             `json:"modelName,omitempty"`
+	Metadata      *Metadata          `json:"metadata,omitempty"`
 	ModelResponse ModelChunkResponse `json:"modelResponse,omitempty"`
 }
 

--- a/pkg/api/schemas/chat_stream.go
+++ b/pkg/api/schemas/chat_stream.go
@@ -15,6 +15,16 @@ type ChatStreamRequest struct {
 	Metadata       *Metadata            `json:"metadata,omitempty"`
 }
 
+func NewChatStreamFromStr(message string) *ChatStreamRequest {
+	return &ChatStreamRequest{
+		Message: ChatMessage{
+			"human",
+			message,
+			"glide",
+		},
+	}
+}
+
 type ModelChunkResponse struct {
 	Metadata     *Metadata     `json:"metadata,omitempty"`
 	Message      ChatMessage   `json:"message"`

--- a/pkg/api/schemas/chat_stream.go
+++ b/pkg/api/schemas/chat_stream.go
@@ -9,6 +9,7 @@ var Complete FinishReason = "complete"
 
 // ChatStreamRequest defines a message that requests a new streaming chat
 type ChatStreamRequest struct {
+	ID             string               `json:"id" validate:"required"`
 	Message        ChatMessage          `json:"message" validate:"required"`
 	MessageHistory []ChatMessage        `json:"messageHistory" validate:"required"`
 	Override       *OverrideChatRequest `json:"overrideMessage,omitempty"`
@@ -33,20 +34,22 @@ type ModelChunkResponse struct {
 
 // ChatStreamChunk defines a message for a chunk of streaming chat response
 type ChatStreamChunk struct {
-	ID            string             `json:"id,omitempty"`
-	CreatedAt     int                `json:"createdAt,omitempty"`
-	Provider      string             `json:"providerId,omitempty"`
-	RouterID      string             `json:"routerId,omitempty"`
-	ModelID       string             `json:"modelId,omitempty"`
-	Cached        bool               `json:"cached,omitempty"`
-	ModelName     string             `json:"modelName,omitempty"`
+	ID            string             `json:"id"`
+	CreatedAt     int                `json:"createdAt"`
+	Provider      string             `json:"providerId"`
+	RouterID      string             `json:"routerId"`
+	ModelID       string             `json:"modelId"`
+	Cached        bool               `json:"cached"`
+	ModelName     string             `json:"modelName"`
 	Metadata      *Metadata          `json:"metadata,omitempty"`
-	ModelResponse ModelChunkResponse `json:"modelResponse,omitempty"`
+	ModelResponse ModelChunkResponse `json:"modelResponse"`
 }
 
 type ChatStreamError struct {
-	Reason  string `json:"reason"`
-	Message string `json:"message"`
+	ID       string    `json:"id"`
+	ErrCode  string    `json:"errCode"`
+	Message  string    `json:"message"`
+	Metadata *Metadata `json:"metadata,omitempty"`
 }
 
 type ChatStreamResult struct {

--- a/pkg/providers/anthropic/chat_stream.go
+++ b/pkg/providers/anthropic/chat_stream.go
@@ -11,6 +11,6 @@ func (c *Client) SupportChatStream() bool {
 	return false
 }
 
-func (c *Client) ChatStream(_ context.Context, _ *schemas.ChatRequest) (clients.ChatStream, error) {
+func (c *Client) ChatStream(_ context.Context, _ *schemas.ChatStreamRequest) (clients.ChatStream, error) {
 	return nil, clients.ErrChatStreamNotImplemented
 }

--- a/pkg/providers/azureopenai/chat_stream.go
+++ b/pkg/providers/azureopenai/chat_stream.go
@@ -11,6 +11,6 @@ func (c *Client) SupportChatStream() bool {
 	return false
 }
 
-func (c *Client) ChatStream(_ context.Context, _ *schemas.ChatRequest) (clients.ChatStream, error) {
+func (c *Client) ChatStream(_ context.Context, _ *schemas.ChatStreamRequest) (clients.ChatStream, error) {
 	return nil, clients.ErrChatStreamNotImplemented
 }

--- a/pkg/providers/bedrock/chat_stream.go
+++ b/pkg/providers/bedrock/chat_stream.go
@@ -11,6 +11,6 @@ func (c *Client) SupportChatStream() bool {
 	return false
 }
 
-func (c *Client) ChatStream(_ context.Context, _ *schemas.ChatRequest) (clients.ChatStream, error) {
+func (c *Client) ChatStream(_ context.Context, _ *schemas.ChatStreamRequest) (clients.ChatStream, error) {
 	return nil, clients.ErrChatStreamNotImplemented
 }

--- a/pkg/providers/cohere/chat_stream.go
+++ b/pkg/providers/cohere/chat_stream.go
@@ -11,6 +11,6 @@ func (c *Client) SupportChatStream() bool {
 	return false
 }
 
-func (c *Client) ChatStream(_ context.Context, _ *schemas.ChatRequest) (clients.ChatStream, error) {
+func (c *Client) ChatStream(_ context.Context, _ *schemas.ChatStreamRequest) (clients.ChatStream, error) {
 	return nil, clients.ErrChatStreamNotImplemented
 }

--- a/pkg/providers/lang.go
+++ b/pkg/providers/lang.go
@@ -19,14 +19,14 @@ type LangProvider interface {
 	SupportChatStream() bool
 
 	Chat(ctx context.Context, req *schemas.ChatRequest) (*schemas.ChatResponse, error)
-	ChatStream(ctx context.Context, req *schemas.ChatRequest) (clients.ChatStream, error)
+	ChatStream(ctx context.Context, req *schemas.ChatStreamRequest) (clients.ChatStream, error)
 }
 
 type LangModel interface {
 	Model
 	Provider() string
 	Chat(ctx context.Context, req *schemas.ChatRequest) (*schemas.ChatResponse, error)
-	ChatStream(ctx context.Context, req *schemas.ChatRequest) (<-chan *clients.ChatStreamResult, error)
+	ChatStream(ctx context.Context, req *schemas.ChatStreamRequest) (<-chan *clients.ChatStreamResult, error)
 }
 
 // LanguageModel wraps provider client and expend it with health & latency tracking
@@ -102,7 +102,7 @@ func (m *LanguageModel) Chat(ctx context.Context, request *schemas.ChatRequest) 
 	return resp, err
 }
 
-func (m *LanguageModel) ChatStream(ctx context.Context, req *schemas.ChatRequest) (<-chan *clients.ChatStreamResult, error) {
+func (m *LanguageModel) ChatStream(ctx context.Context, req *schemas.ChatStreamRequest) (<-chan *clients.ChatStreamResult, error) {
 	stream, err := m.client.ChatStream(ctx, req)
 	if err != nil {
 		m.healthTracker.TrackErr(err)

--- a/pkg/providers/octoml/chat_stream.go
+++ b/pkg/providers/octoml/chat_stream.go
@@ -11,6 +11,6 @@ func (c *Client) SupportChatStream() bool {
 	return false
 }
 
-func (c *Client) ChatStream(_ context.Context, _ *schemas.ChatRequest) (clients.ChatStream, error) {
+func (c *Client) ChatStream(_ context.Context, _ *schemas.ChatStreamRequest) (clients.ChatStream, error) {
 	return nil, clients.ErrChatStreamNotImplemented
 }

--- a/pkg/providers/ollama/chat_stream.go
+++ b/pkg/providers/ollama/chat_stream.go
@@ -11,6 +11,6 @@ func (c *Client) SupportChatStream() bool {
 	return false
 }
 
-func (c *Client) ChatStream(_ context.Context, _ *schemas.ChatRequest) (clients.ChatStream, error) {
+func (c *Client) ChatStream(_ context.Context, _ *schemas.ChatStreamRequest) (clients.ChatStream, error) {
 	return nil, clients.ErrChatStreamNotImplemented
 }

--- a/pkg/providers/openai/chat_stream.go
+++ b/pkg/providers/openai/chat_stream.go
@@ -24,20 +24,22 @@ var (
 
 // ChatStream represents OpenAI chat stream for a specific request
 type ChatStream struct {
-	tel       *telemetry.Telemetry
-	client    *http.Client
-	req       *http.Request
-	resp      *http.Response
-	reader    *sse.EventStreamReader
-	errMapper *ErrorMapper
+	tel         *telemetry.Telemetry
+	client      *http.Client
+	req         *http.Request
+	reqMetadata *schemas.Metadata
+	resp        *http.Response
+	reader      *sse.EventStreamReader
+	errMapper   *ErrorMapper
 }
 
-func NewChatStream(tel *telemetry.Telemetry, client *http.Client, req *http.Request, errMapper *ErrorMapper) *ChatStream {
+func NewChatStream(tel *telemetry.Telemetry, client *http.Client, req *http.Request, reqMetadata *schemas.Metadata, errMapper *ErrorMapper) *ChatStream {
 	return &ChatStream{
-		tel:       tel,
-		client:    client,
-		req:       req,
-		errMapper: errMapper,
+		tel:         tel,
+		client:      client,
+		req:         req,
+		reqMetadata: reqMetadata,
+		errMapper:   errMapper,
 	}
 }
 
@@ -120,7 +122,7 @@ func (s *ChatStream) Recv() (*schemas.ChatStreamChunk, error) {
 			Provider:  providerName,
 			Cached:    false,
 			ModelName: completionChunk.ModelName,
-			// TODO: set request metadata
+			Metadata:  s.reqMetadata,
 			ModelResponse: schemas.ModelChunkResponse{
 				Metadata: &schemas.Metadata{
 					"response_id":        completionChunk.ID,
@@ -159,6 +161,7 @@ func (c *Client) ChatStream(ctx context.Context, req *schemas.ChatStreamRequest)
 		c.tel,
 		c.httpClient,
 		httpRequest,
+		req.Metadata,
 		c.errMapper,
 	), nil
 }

--- a/pkg/providers/openai/chat_stream.go
+++ b/pkg/providers/openai/chat_stream.go
@@ -27,17 +27,26 @@ type ChatStream struct {
 	tel         *telemetry.Telemetry
 	client      *http.Client
 	req         *http.Request
+	reqID       string
 	reqMetadata *schemas.Metadata
 	resp        *http.Response
 	reader      *sse.EventStreamReader
 	errMapper   *ErrorMapper
 }
 
-func NewChatStream(tel *telemetry.Telemetry, client *http.Client, req *http.Request, reqMetadata *schemas.Metadata, errMapper *ErrorMapper) *ChatStream {
+func NewChatStream(
+	tel *telemetry.Telemetry,
+	client *http.Client,
+	req *http.Request,
+	reqID string,
+	reqMetadata *schemas.Metadata,
+	errMapper *ErrorMapper,
+) *ChatStream {
 	return &ChatStream{
 		tel:         tel,
 		client:      client,
 		req:         req,
+		reqID:       reqID,
 		reqMetadata: reqMetadata,
 		errMapper:   errMapper,
 	}
@@ -118,7 +127,7 @@ func (s *ChatStream) Recv() (*schemas.ChatStreamChunk, error) {
 
 		// TODO: use objectpool here
 		return &schemas.ChatStreamChunk{
-			ID:        completionChunk.ID,
+			ID:        s.reqID,
 			Provider:  providerName,
 			Cached:    false,
 			ModelName: completionChunk.ModelName,
@@ -161,6 +170,7 @@ func (c *Client) ChatStream(ctx context.Context, req *schemas.ChatStreamRequest)
 		c.tel,
 		c.httpClient,
 		httpRequest,
+		req.ID,
 		req.Metadata,
 		c.errMapper,
 	), nil

--- a/pkg/providers/openai/chat_stream_test.go
+++ b/pkg/providers/openai/chat_stream_test.go
@@ -69,12 +69,8 @@ func TestOpenAIClient_ChatStreamRequest(t *testing.T) {
 			client, err := NewClient(providerCfg, clientCfg, telemetry.NewTelemetryMock())
 			require.NoError(t, err)
 
-			req := schemas.ChatRequest{Message: schemas.ChatMessage{
-				Role:    "user",
-				Content: "What's the capital of the United Kingdom?",
-			}}
-
-			stream, err := client.ChatStream(ctx, &req)
+			req := schemas.NewChatStreamFromStr("What's the capital of the United Kingdom?")
+			stream, err := client.ChatStream(ctx, req)
 			require.NoError(t, err)
 
 			err = stream.Open()
@@ -137,12 +133,8 @@ func TestOpenAIClient_ChatStreamRequestInterrupted(t *testing.T) {
 			client, err := NewClient(providerCfg, clientCfg, telemetry.NewTelemetryMock())
 			require.NoError(t, err)
 
-			req := schemas.ChatRequest{Message: schemas.ChatMessage{
-				Role:    "user",
-				Content: "What's the capital of the United Kingdom?",
-			}}
-
-			stream, err := client.ChatStream(ctx, &req)
+			req := schemas.NewChatStreamFromStr("What's the capital of the United Kingdom?")
+			stream, err := client.ChatStream(ctx, req)
 			require.NoError(t, err)
 
 			err = stream.Open()

--- a/pkg/providers/testing/lang.go
+++ b/pkg/providers/testing/lang.go
@@ -31,10 +31,7 @@ func (m *RespMock) Resp() *schemas.ChatResponse {
 func (m *RespMock) RespChunk() *schemas.ChatStreamChunk {
 	return &schemas.ChatStreamChunk{
 		ID: "rsp0001",
-		ModelResponse: schemas.ModelResponse{
-			SystemID: map[string]string{
-				"ID": "0001",
-			},
+		ModelResponse: schemas.ModelChunkResponse{
 			Message: schemas.ChatMessage{
 				Content: m.Msg,
 			},

--- a/pkg/providers/testing/lang.go
+++ b/pkg/providers/testing/lang.go
@@ -139,7 +139,7 @@ func (c *ProviderMock) Chat(_ context.Context, _ *schemas.ChatRequest) (*schemas
 	return response.Resp(), nil
 }
 
-func (c *ProviderMock) ChatStream(_ context.Context, _ *schemas.ChatRequest) (clients.ChatStream, error) {
+func (c *ProviderMock) ChatStream(_ context.Context, _ *schemas.ChatStreamRequest) (clients.ChatStream, error) {
 	if c.chatStreams == nil || c.idx >= len(*c.chatStreams) {
 		return nil, clients.ErrProviderUnavailable
 	}

--- a/pkg/routers/router.go
+++ b/pkg/routers/router.go
@@ -124,7 +124,7 @@ func (r *LangRouter) Chat(ctx context.Context, req *schemas.ChatRequest) (*schem
 
 func (r *LangRouter) ChatStream(
 	ctx context.Context,
-	req *schemas.ChatRequest,
+	req *schemas.ChatStreamRequest,
 	respC chan<- *schemas.ChatStreamResult,
 ) {
 	if len(r.chatStreamModels) == 0 {

--- a/pkg/routers/router.go
+++ b/pkg/routers/router.go
@@ -129,8 +129,10 @@ func (r *LangRouter) ChatStream(
 ) {
 	if len(r.chatStreamModels) == 0 {
 		respC <- schemas.NewChatStreamErrorResult(&schemas.ChatStreamError{
-			Reason:  "noModels",
-			Message: ErrNoModels.Error(),
+			ID:       req.ID,
+			ErrCode:  "noModels",
+			Message:  ErrNoModels.Error(),
+			Metadata: req.Metadata,
 		})
 
 		return
@@ -179,8 +181,10 @@ func (r *LangRouter) ChatStream(
 					//  may have already used all chunks we streamed this far (e.g. showed them to their users like OpenAI UI does),
 					//  so we cannot easily restart that process from scratch
 					respC <- schemas.NewChatStreamErrorResult(&schemas.ChatStreamError{
-						Reason:  "modelUnavailable",
-						Message: err.Error(),
+						ID:       req.ID,
+						ErrCode:  "modelUnavailable",
+						Message:  err.Error(),
+						Metadata: req.Metadata,
 					})
 
 					continue NextModel
@@ -203,8 +207,10 @@ func (r *LangRouter) ChatStream(
 		if err != nil {
 			// something has cancelled the context
 			respC <- schemas.NewChatStreamErrorResult(&schemas.ChatStreamError{
-				Reason:  "other",
-				Message: err.Error(),
+				ID:       req.ID,
+				ErrCode:  "other",
+				Message:  err.Error(),
+				Metadata: req.Metadata,
 			})
 
 			return
@@ -218,7 +224,9 @@ func (r *LangRouter) ChatStream(
 	)
 
 	respC <- schemas.NewChatStreamErrorResult(&schemas.ChatStreamError{
-		Reason:  "allModelsUnavailable",
-		Message: ErrNoModelAvailable.Error(),
+		ID:       req.ID,
+		ErrCode:  "allModelsUnavailable",
+		Message:  ErrNoModelAvailable.Error(),
+		Metadata: req.Metadata,
 	})
 }

--- a/pkg/routers/router_test.go
+++ b/pkg/routers/router_test.go
@@ -305,7 +305,7 @@ func TestLangRouter_ChatStream(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	req := schemas.NewChatFromStr("tell me a dad joke")
+	req := schemas.NewChatStreamFromStr("tell me a dad joke")
 	respC := make(chan *schemas.ChatStreamResult)
 
 	defer close(respC)
@@ -373,7 +373,7 @@ func TestLangRouter_ChatStream_FailOnFirst(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	req := schemas.NewChatFromStr("tell me a dad joke")
+	req := schemas.NewChatStreamFromStr("tell me a dad joke")
 	respC := make(chan *schemas.ChatStreamResult)
 
 	defer close(respC)
@@ -443,7 +443,7 @@ func TestLangRouter_ChatStream_AllModelsUnavailable(t *testing.T) {
 	respC := make(chan *schemas.ChatStreamResult)
 	defer close(respC)
 
-	go router.ChatStream(context.Background(), schemas.NewChatFromStr("tell me a dad joke"), respC)
+	go router.ChatStream(context.Background(), schemas.NewChatStreamFromStr("tell me a dad joke"), respC)
 
 	errs := make([]string, 0, 3)
 

--- a/pkg/routers/router_test.go
+++ b/pkg/routers/router_test.go
@@ -451,7 +451,7 @@ func TestLangRouter_ChatStream_AllModelsUnavailable(t *testing.T) {
 		result := <-respC
 		require.Nil(t, result.Chunk())
 
-		errs = append(errs, result.Error().Reason)
+		errs = append(errs, result.Error().ErrCode)
 	}
 
 	require.Equal(t, []string{"modelUnavailable", "modelUnavailable", "allModelsUnavailable"}, errs)


### PR DESCRIPTION
## Changes

- Separated chat & chat stream request schemas 
- introduced a new finish reason field 
- added metadata to stream chat response
- allow to attach some metadata to a chat stream request and then attach it to each chat stream chunk
- adjusted error message schema to include request ID and metadata