### PR TITLE
🔧 #186: Rendering Durations in a human-friendly way

### DIFF
--- a/pkg/config/fields/duration.go
+++ b/pkg/config/fields/duration.go
@@ -1,0 +1,10 @@
+package fields
+
+import "time"
+
+type Duration time.Duration
+
+// MarshalText serializes Durations in a human-friendly way (it's shown in nanoseconds by default)
+func (d Duration) MarshalText() ([]byte, error) {
+	return []byte(time.Duration(d).String()), nil
+}

--- a/pkg/providers/lang.go
+++ b/pkg/providers/lang.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"time"
 
+	"glide/pkg/config/fields"
+
 	"glide/pkg/routers/health"
 
 	"glide/pkg/api/schemas"
@@ -40,7 +42,7 @@ type LanguageModel struct {
 	healthTracker         *health.Tracker
 	chatLatency           *latency.MovingAverage
 	chatStreamLatency     *latency.MovingAverage
-	latencyUpdateInterval *time.Duration
+	latencyUpdateInterval *fields.Duration
 }
 
 func NewLangModel(modelID string, client LangProvider, budget *health.ErrorBudget, latencyConfig latency.Config, weight int) *LanguageModel {
@@ -67,7 +69,7 @@ func (m LanguageModel) Weight() int {
 	return m.weight
 }
 
-func (m LanguageModel) LatencyUpdateInterval() *time.Duration {
+func (m LanguageModel) LatencyUpdateInterval() *fields.Duration {
 	return m.latencyUpdateInterval
 }
 

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -1,7 +1,7 @@
 package providers
 
 import (
-	"time"
+	"glide/pkg/config/fields"
 )
 
 // ModelProvider exposes provider context
@@ -13,6 +13,6 @@ type ModelProvider interface {
 type Model interface {
 	ID() string
 	Healthy() bool
-	LatencyUpdateInterval() *time.Duration
+	LatencyUpdateInterval() *fields.Duration
 	Weight() int
 }

--- a/pkg/providers/testing/models.go
+++ b/pkg/providers/testing/models.go
@@ -3,6 +3,8 @@ package testing
 import (
 	"time"
 
+	"glide/pkg/config/fields"
+
 	"glide/pkg/providers"
 	"glide/pkg/routers/latency"
 )
@@ -42,10 +44,10 @@ func (m *LangModelMock) ChatLatency() *latency.MovingAverage {
 	return m.chatLatency
 }
 
-func (m LangModelMock) LatencyUpdateInterval() *time.Duration {
+func (m LangModelMock) LatencyUpdateInterval() *fields.Duration {
 	updateInterval := 30 * time.Second
 
-	return &updateInterval
+	return (*fields.Duration)(&updateInterval)
 }
 
 func (m LangModelMock) Weight() int {

--- a/pkg/routers/latency/config.go
+++ b/pkg/routers/latency/config.go
@@ -1,12 +1,16 @@
 package latency
 
-import "time"
+import (
+	"time"
+
+	"glide/pkg/config/fields"
+)
 
 // Config defines setting for moving average latency calculations
 type Config struct {
-	Decay          float64        `yaml:"decay" json:"decay"`                                                              // Weight of new latency measurements
-	WarmupSamples  uint8          `yaml:"warmup_samples" json:"warmup_samples"`                                            // The number of latency probes required to init moving average
-	UpdateInterval *time.Duration `yaml:"update_interval,omitempty" json:"update_interval" swaggertype:"primitive,string"` // How often gateway should probe models with not the lowest response latency
+	Decay          float64          `yaml:"decay" json:"decay"`                                                              // Weight of new latency measurements
+	WarmupSamples  uint8            `yaml:"warmup_samples" json:"warmup_samples"`                                            // The number of latency probes required to init moving average
+	UpdateInterval *fields.Duration `yaml:"update_interval,omitempty" json:"update_interval" swaggertype:"primitive,string"` // How often gateway should probe models with not the lowest response latency
 }
 
 func DefaultConfig() *Config {
@@ -15,6 +19,6 @@ func DefaultConfig() *Config {
 	return &Config{
 		Decay:          0.06,
 		WarmupSamples:  3,
-		UpdateInterval: &defaultUpdateInterval,
+		UpdateInterval: (*fields.Duration)(&defaultUpdateInterval),
 	}
 }

--- a/pkg/routers/routing/least_latency.go
+++ b/pkg/routers/routing/least_latency.go
@@ -53,7 +53,7 @@ func (s *ModelSchedule) Update() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.expireAt = time.Now().Add(*s.model.LatencyUpdateInterval())
+	s.expireAt = time.Now().Add(time.Duration(*s.model.LatencyUpdateInterval()))
 }
 
 // LeastLatencyRouting routes requests to the model that responses the fastest


### PR DESCRIPTION
Rendering Durations as strings rather than nanosecond integers:

<img width="1000" alt="Screenshot 2024-04-11 at 23 50 26" src="https://github.com/EinStack/glide/assets/9402690/05ddca36-6511-401c-9bda-e060d9642637">
