### PR TITLE
🔧 #195 #196: Set router ctx in stream chunks & handle end of stream in case of some errors

### DIFF
--- a/pkg/api/schemas/chat_stream.go
+++ b/pkg/api/schemas/chat_stream.go
@@ -1,20 +1,34 @@
 package schemas
 
+import "time"
+
 type (
 	Metadata     = map[string]any
+	EventType    = string
 	FinishReason = string
+	ErrorCode    = string
 )
 
 var (
 	Complete        FinishReason = "complete"
 	MaxTokens       FinishReason = "max_tokens"
 	ContentFiltered FinishReason = "content_filtered"
-	Other           FinishReason = "other"
+	ErrorReason     FinishReason = "error"
+	OtherReason     FinishReason = "other"
 )
+
+var (
+	NoModelConfigured    ErrorCode = "no_model_configured"
+	ModelUnavailable     ErrorCode = "model_unavailable"
+	AllModelsUnavailable ErrorCode = "all_models_unavailable"
+	UnknownError         ErrorCode = "unknown_error"
+)
+
+type StreamRequestID = string
 
 // ChatStreamRequest defines a message that requests a new streaming chat
 type ChatStreamRequest struct {
-	ID             string               `json:"id" validate:"required"`
+	ID             StreamRequestID      `json:"id" validate:"required"`
 	Message        ChatMessage          `json:"message" validate:"required"`
 	MessageHistory []ChatMessage        `json:"messageHistory" validate:"required"`
 	Override       *OverrideChatRequest `json:"overrideMessage,omitempty"`
@@ -32,54 +46,64 @@ func NewChatStreamFromStr(message string) *ChatStreamRequest {
 }
 
 type ModelChunkResponse struct {
-	Metadata     *Metadata     `json:"metadata,omitempty"`
-	Message      ChatMessage   `json:"message"`
-	FinishReason *FinishReason `json:"finishReason,omitempty"`
+	Metadata *Metadata   `json:"metadata,omitempty"`
+	Message  ChatMessage `json:"message"`
+}
+
+type ChatStreamMessage struct {
+	ID        StreamRequestID  `json:"id"`
+	CreatedAt int              `json:"createdAt"`
+	RouterID  string           `json:"routerId"`
+	Metadata  *Metadata        `json:"metadata,omitempty"`
+	Chunk     *ChatStreamChunk `json:"chunk,omitempty"`
+	Error     *ChatStreamError `json:"error,omitempty"`
 }
 
 // ChatStreamChunk defines a message for a chunk of streaming chat response
 type ChatStreamChunk struct {
-	ID            string             `json:"id"`
-	CreatedAt     int                `json:"createdAt"`
-	Provider      string             `json:"providerId"`
-	RouterID      string             `json:"routerId"`
 	ModelID       string             `json:"modelId"`
-	Cached        bool               `json:"cached"`
+	Provider      string             `json:"providerName"`
 	ModelName     string             `json:"modelName"`
-	Metadata      *Metadata          `json:"metadata,omitempty"`
+	Cached        bool               `json:"cached"`
 	ModelResponse ModelChunkResponse `json:"modelResponse"`
+	FinishReason  *FinishReason      `json:"finishReason,omitempty"`
 }
 
 type ChatStreamError struct {
-	ID       string    `json:"id"`
-	ErrCode  string    `json:"errCode"`
-	Message  string    `json:"message"`
-	Metadata *Metadata `json:"metadata,omitempty"`
+	ErrCode ErrorCode `json:"errCode"`
+	Message string    `json:"message"`
 }
 
-type ChatStreamResult struct {
-	chunk *ChatStreamChunk
-	err   *ChatStreamError
-}
-
-func (r *ChatStreamResult) Chunk() *ChatStreamChunk {
-	return r.chunk
-}
-
-func (r *ChatStreamResult) Error() *ChatStreamError {
-	return r.err
-}
-
-func NewChatStreamResult(chunk *ChatStreamChunk) *ChatStreamResult {
-	return &ChatStreamResult{
-		chunk: chunk,
-		err:   nil,
+func NewChatStreamChunk(
+	reqID StreamRequestID,
+	routerID string,
+	reqMetadata *Metadata,
+	chunk *ChatStreamChunk,
+) *ChatStreamMessage {
+	return &ChatStreamMessage{
+		ID:        reqID,
+		RouterID:  routerID,
+		CreatedAt: int(time.Now().UTC().Unix()),
+		Metadata:  reqMetadata,
+		Chunk:     chunk,
 	}
 }
 
-func NewChatStreamErrorResult(err *ChatStreamError) *ChatStreamResult {
-	return &ChatStreamResult{
-		chunk: nil,
-		err:   err,
+func NewChatStreamError(
+	reqID StreamRequestID,
+	routerID string,
+	errCode ErrorCode,
+	errMsg string,
+	reqMetadata *Metadata,
+) *ChatStreamMessage {
+	return &ChatStreamMessage{
+		ID:        reqID,
+		RouterID:  routerID,
+		CreatedAt: int(time.Now().UTC().Unix()),
+		Metadata:  reqMetadata,
+		Error: &ChatStreamError{
+			ErrCode: errCode,
+			Message: errMsg,
+		},
 	}
 }

--- a/pkg/api/schemas/chat_stream.go
+++ b/pkg/api/schemas/chat_stream.go
@@ -70,8 +70,9 @@ type ChatStreamChunk struct {
 }
 
 type ChatStreamError struct {
-	ErrCode ErrorCode `json:"errCode"`
-	Message string    `json:"message"`
+	ErrCode      ErrorCode     `json:"errCode"`
+	Message      string        `json:"message"`
+	FinishReason *FinishReason `json:"finishReason,omitempty"`
 }
 
 func NewChatStreamChunk(
@@ -95,6 +96,7 @@ func NewChatStreamError(
 	errCode ErrorCode,
 	errMsg string,
 	reqMetadata *Metadata,
+	finishReason *FinishReason,
 ) *ChatStreamMessage {
 	return &ChatStreamMessage{
 		ID:        reqID,
@@ -102,8 +104,9 @@ func NewChatStreamError(
 		CreatedAt: int(time.Now().UTC().Unix()),
 		Metadata:  reqMetadata,
 		Error: &ChatStreamError{
-			ErrCode: errCode,
-			Message: errMsg,
+			ErrCode:      errCode,
+			Message:      errMsg,
+			FinishReason: finishReason,
 		},
 	}
 }

--- a/pkg/providers/azureopenai/chat_stream.go
+++ b/pkg/providers/azureopenai/chat_stream.go
@@ -123,8 +123,8 @@ func (s *ChatStream) Recv() (*schemas.ChatStreamChunk, error) {
 
 		// TODO: use objectpool here
 		return &schemas.ChatStreamChunk{
-			Provider:  providerName,
 			Cached:    false,
+			Provider:  providerName,
 			ModelName: completionChunk.ModelName,
 			ModelResponse: schemas.ModelChunkResponse{
 				Metadata: &schemas.Metadata{

--- a/pkg/providers/cohere/chat.go
+++ b/pkg/providers/cohere/chat.go
@@ -108,7 +108,7 @@ func (c *Client) doChatRequest(ctx context.Context, payload *ChatRequest) (*sche
 		c.tel.Logger.Error(
 			"cohere chat request failed",
 			zap.Int("status_code", resp.StatusCode),
-			zap.String("response", string(bodyBytes)),
+			zap.ByteString("response", bodyBytes),
 			zap.Any("headers", resp.Header),
 		)
 
@@ -124,15 +124,6 @@ func (c *Client) doChatRequest(ctx context.Context, payload *ChatRequest) (*sche
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		c.tel.Logger.Error("failed to read cohere chat response", zap.Error(err))
-		return nil, err
-	}
-
-	// Parse the response JSON
-	var responseJSON map[string]interface{}
-
-	err = json.Unmarshal(bodyBytes, &responseJSON)
-	if err != nil {
-		c.tel.Logger.Error("failed to parse cohere chat response", zap.Error(err))
 		return nil, err
 	}
 

--- a/pkg/providers/cohere/chat_stream.go
+++ b/pkg/providers/cohere/chat_stream.go
@@ -5,10 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"glide/pkg/providers/clients"
-	"glide/pkg/telemetry"
 	"io"
 	"net/http"
+
+	"glide/pkg/providers/clients"
+	"glide/pkg/telemetry"
 
 	"go.uber.org/zap"
 
@@ -29,9 +30,7 @@ var (
 type ChatStream struct {
 	client             *http.Client
 	req                *http.Request
-	reqID              string
 	modelName          string
-	reqMetadata        *schemas.Metadata
 	resp               *http.Response
 	generationID       string
 	streamFinished     bool
@@ -46,7 +45,6 @@ func NewChatStream(
 	client *http.Client,
 	req *http.Request,
 	modelName string,
-	reqMetadata *schemas.Metadata,
 	errMapper *ErrorMapper,
 	finishReasonMapper *FinishReasonMapper,
 ) *ChatStream {
@@ -55,7 +53,6 @@ func NewChatStream(
 		client:             client,
 		req:                req,
 		modelName:          modelName,
-		reqMetadata:        reqMetadata,
 		errMapper:          errMapper,
 		streamFinished:     false,
 		finishReasonMapper: finishReasonMapper,
@@ -133,13 +130,13 @@ func (s *ChatStream) Recv() (*schemas.ChatStreamChunk, error) {
 
 			// TODO: use objectpool here
 			return &schemas.ChatStreamChunk{
-				Provider:  providerName,
 				Cached:    false,
+				Provider:  providerName,
 				ModelName: s.modelName,
 				ModelResponse: schemas.ModelChunkResponse{
 					Metadata: &schemas.Metadata{
-						"generationId": s.generationID,
-						"responseId":   responseChunk.Response.ResponseID,
+						"generation_id": s.generationID,
+						"response_id":   responseChunk.Response.ResponseID,
 					},
 					Message: schemas.ChatMessage{
 						Role:    "model",
@@ -152,12 +149,12 @@ func (s *ChatStream) Recv() (*schemas.ChatStreamChunk, error) {
 
 		// TODO: use objectpool here
 		return &schemas.ChatStreamChunk{
-			Provider:  providerName,
 			Cached:    false,
+			Provider:  providerName,
 			ModelName: s.modelName,
 			ModelResponse: schemas.ModelChunkResponse{
 				Metadata: &schemas.Metadata{
-					"generationId": s.generationID,
+					"generation_id": s.generationID,
 				},
 				Message: schemas.ChatMessage{
 					Role:    "model",
@@ -192,7 +189,6 @@ func (c *Client) ChatStream(ctx context.Context, req *schemas.ChatStreamRequest)
 		c.httpClient,
 		httpRequest,
 		c.chatRequestTemplate.Model,
-		req.Metadata,
 		c.errMapper,
 		c.finishReasonMapper,
 	), nil

--- a/pkg/providers/cohere/chat_stream.go
+++ b/pkg/providers/cohere/chat_stream.go
@@ -5,11 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-
 	"glide/pkg/providers/clients"
 	"glide/pkg/telemetry"
+	"io"
+	"net/http"
 
 	"go.uber.org/zap"
 
@@ -46,7 +45,6 @@ func NewChatStream(
 	tel *telemetry.Telemetry,
 	client *http.Client,
 	req *http.Request,
-	reqID string,
 	modelName string,
 	reqMetadata *schemas.Metadata,
 	errMapper *ErrorMapper,
@@ -56,7 +54,6 @@ func NewChatStream(
 		tel:                tel,
 		client:             client,
 		req:                req,
-		reqID:              reqID,
 		modelName:          modelName,
 		reqMetadata:        reqMetadata,
 		errMapper:          errMapper,
@@ -136,11 +133,9 @@ func (s *ChatStream) Recv() (*schemas.ChatStreamChunk, error) {
 
 			// TODO: use objectpool here
 			return &schemas.ChatStreamChunk{
-				ID:        s.reqID,
 				Provider:  providerName,
 				Cached:    false,
 				ModelName: s.modelName,
-				Metadata:  s.reqMetadata,
 				ModelResponse: schemas.ModelChunkResponse{
 					Metadata: &schemas.Metadata{
 						"generationId": s.generationID,
@@ -150,18 +145,16 @@ func (s *ChatStream) Recv() (*schemas.ChatStreamChunk, error) {
 						Role:    "model",
 						Content: responseChunk.Text,
 					},
-					FinishReason: s.finishReasonMapper.Map(responseChunk.FinishReason),
 				},
+				FinishReason: s.finishReasonMapper.Map(responseChunk.FinishReason),
 			}, nil
 		}
 
 		// TODO: use objectpool here
 		return &schemas.ChatStreamChunk{
-			ID:        s.reqID,
 			Provider:  providerName,
 			Cached:    false,
 			ModelName: s.modelName,
-			Metadata:  s.reqMetadata,
 			ModelResponse: schemas.ModelChunkResponse{
 				Metadata: &schemas.Metadata{
 					"generationId": s.generationID,
@@ -198,7 +191,6 @@ func (c *Client) ChatStream(ctx context.Context, req *schemas.ChatStreamRequest)
 		c.tel,
 		c.httpClient,
 		httpRequest,
-		req.ID,
 		c.chatRequestTemplate.Model,
 		req.Metadata,
 		c.errMapper,

--- a/pkg/providers/cohere/finish_reason.go
+++ b/pkg/providers/cohere/finish_reason.go
@@ -46,7 +46,7 @@ func (m *FinishReasonMapper) Map(finishReason *string) *schemas.FinishReason {
 			zap.String("unknown_reason", *finishReason),
 		)
 
-		reason = &schemas.Other
+		reason = &schemas.OtherReason
 	}
 
 	return reason

--- a/pkg/providers/lang.go
+++ b/pkg/providers/lang.go
@@ -151,6 +151,8 @@ func (m *LanguageModel) ChatStream(ctx context.Context, req *schemas.ChatStreamR
 				return
 			}
 
+			chunk.ModelID = m.modelID
+
 			streamResultC <- clients.NewChatStreamResult(chunk, nil)
 
 			if chunkLatency > 1*time.Millisecond {

--- a/pkg/providers/lang.go
+++ b/pkg/providers/lang.go
@@ -89,17 +89,17 @@ func (m *LanguageModel) Chat(ctx context.Context, request *schemas.ChatRequest) 
 	startedAt := time.Now()
 	resp, err := m.client.Chat(ctx, request)
 
-	if err == nil {
-		// record latency per token to normalize measurements
-		m.chatLatency.Add(float64(time.Since(startedAt)) / float64(resp.ModelResponse.TokenUsage.ResponseTokens))
-
-		// successful response
-		resp.ModelID = m.modelID
+	if err != nil {
+		m.healthTracker.TrackErr(err)
 
 		return resp, err
 	}
 
-	m.healthTracker.TrackErr(err)
+	// record latency per token to normalize measurements
+	m.chatLatency.Add(float64(time.Since(startedAt)) / float64(resp.ModelResponse.TokenUsage.ResponseTokens))
+
+	// successful response
+	resp.ModelID = m.modelID
 
 	return resp, err
 }

--- a/pkg/providers/lang.go
+++ b/pkg/providers/lang.go
@@ -87,8 +87,8 @@ func (m LanguageModel) ChatStreamLatency() *latency.MovingAverage {
 
 func (m *LanguageModel) Chat(ctx context.Context, request *schemas.ChatRequest) (*schemas.ChatResponse, error) {
 	startedAt := time.Now()
-	resp, err := m.client.Chat(ctx, request)
 
+	resp, err := m.client.Chat(ctx, request)
 	if err != nil {
 		m.healthTracker.TrackErr(err)
 

--- a/pkg/providers/openai/chat.go
+++ b/pkg/providers/openai/chat.go
@@ -84,9 +84,8 @@ func (c *Client) doChatRequest(ctx context.Context, payload *ChatRequest) (*sche
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", string(c.config.APIKey)))
 
 	// TODO: this could leak information from messages which may not be a desired thing to have
-	c.tel.Logger.Debug(
+	c.logger.Debug(
 		"Chat Request",
-		zap.String("provider", c.Provider()),
 		zap.String("chatURL", c.chatURL),
 		zap.Any("payload", payload),
 	)
@@ -105,9 +104,9 @@ func (c *Client) doChatRequest(ctx context.Context, payload *ChatRequest) (*sche
 	// Read the response body into a byte slice
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		c.tel.Logger.Error(
+		c.logger.Error(
 			"Failed to read chat response",
-			zap.String("provider", c.Provider()), zap.Error(err),
+			zap.Error(err),
 			zap.ByteString("rawResponse", bodyBytes),
 		)
 
@@ -119,9 +118,8 @@ func (c *Client) doChatRequest(ctx context.Context, payload *ChatRequest) (*sche
 
 	err = json.Unmarshal(bodyBytes, &chatCompletion)
 	if err != nil {
-		c.tel.Logger.Error(
+		c.logger.Error(
 			"Failed to unmarshal chat response",
-			zap.String("provider", c.Provider()),
 			zap.ByteString("rawResponse", bodyBytes),
 			zap.Error(err),
 		)

--- a/pkg/providers/openai/client.go
+++ b/pkg/providers/openai/client.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/url"
 
+	"go.uber.org/zap"
+
 	"glide/pkg/providers/clients"
 	"glide/pkg/telemetry"
 )
@@ -28,6 +30,7 @@ type Client struct {
 	config              *Config
 	httpClient          *http.Client
 	tel                 *telemetry.Telemetry
+	logger              *zap.Logger
 }
 
 // NewClient creates a new OpenAI client for the OpenAI API.
@@ -36,6 +39,10 @@ func NewClient(providerConfig *Config, clientConfig *clients.ClientConfig, tel *
 	if err != nil {
 		return nil, err
 	}
+
+	logger := tel.L().With(
+		zap.String("provider", providerName),
+	)
 
 	c := &Client{
 		baseURL:             providerConfig.BaseURL,
@@ -52,7 +59,8 @@ func NewClient(providerConfig *Config, clientConfig *clients.ClientConfig, tel *
 				MaxIdleConnsPerHost: 2,
 			},
 		},
-		tel: tel,
+		tel:    tel,
+		logger: logger,
 	}
 
 	return c, nil

--- a/pkg/providers/openai/finish_reasons.go
+++ b/pkg/providers/openai/finish_reasons.go
@@ -44,7 +44,7 @@ func (m *FinishReasonMapper) Map(finishReason string) *schemas.FinishReason {
 			zap.String("unknown_reason", finishReason),
 		)
 
-		reason = &schemas.Other
+		reason = &schemas.OtherReason
 	}
 
 	return reason

--- a/pkg/providers/testing/lang.go
+++ b/pkg/providers/testing/lang.go
@@ -30,7 +30,6 @@ func (m *RespMock) Resp() *schemas.ChatResponse {
 
 func (m *RespMock) RespChunk() *schemas.ChatStreamChunk {
 	return &schemas.ChatStreamChunk{
-		ID: "rsp0001",
 		ModelResponse: schemas.ModelChunkResponse{
 			Message: schemas.ChatMessage{
 				Content: m.Msg,

--- a/pkg/routers/router.go
+++ b/pkg/routers/router.go
@@ -190,7 +190,11 @@ func (r *LangRouter) ChatStream(
 					continue NextModel
 				}
 
-				respC <- schemas.NewChatStreamResult(chunkResult.Chunk())
+				chunk := chunkResult.Chunk()
+
+				chunk.RouterID = r.routerID
+
+				respC <- schemas.NewChatStreamResult(chunk)
 			}
 
 			return

--- a/pkg/routers/router.go
+++ b/pkg/routers/router.go
@@ -137,6 +137,7 @@ func (r *LangRouter) ChatStream(
 			schemas.NoModelConfigured,
 			ErrNoModels.Error(),
 			req.Metadata,
+			&schemas.ErrorReason,
 		)
 
 		return
@@ -188,6 +189,7 @@ func (r *LangRouter) ChatStream(
 						schemas.ModelUnavailable,
 						err.Error(),
 						req.Metadata,
+						nil,
 					)
 
 					continue NextModel
@@ -219,6 +221,7 @@ func (r *LangRouter) ChatStream(
 				schemas.UnknownError,
 				err.Error(),
 				req.Metadata,
+				nil,
 			)
 
 			return
@@ -237,5 +240,6 @@ func (r *LangRouter) ChatStream(
 		schemas.AllModelsUnavailable,
 		ErrNoModelAvailable.Error(),
 		req.Metadata,
+		&schemas.ErrorReason,
 	)
 }

--- a/pkg/routers/router.go
+++ b/pkg/routers/router.go
@@ -19,8 +19,10 @@ var (
 	ErrNoModelAvailable = errors.New("could not handle request because all providers are not available")
 )
 
+type RouterID = string
+
 type LangRouter struct {
-	routerID          string
+	routerID          RouterID
 	Config            *LangRouterConfig
 	chatModels        []*providers.LanguageModel
 	chatStreamModels  []*providers.LanguageModel
@@ -28,6 +30,7 @@ type LangRouter struct {
 	chatStreamRouting routing.LangModelRouting
 	retry             *retry.ExpRetry
 	tel               *telemetry.Telemetry
+	logger            *zap.Logger
 }
 
 func NewLangRouter(cfg *LangRouterConfig, tel *telemetry.Telemetry) (*LangRouter, error) {
@@ -50,12 +53,13 @@ func NewLangRouter(cfg *LangRouterConfig, tel *telemetry.Telemetry) (*LangRouter
 		chatRouting:       chatRouting,
 		chatStreamRouting: chatStreamRouting,
 		tel:               tel,
+		logger:            tel.L().With(zap.String("routerID", cfg.ID)),
 	}
 
 	return router, err
 }
 
-func (r *LangRouter) ID() string {
+func (r *LangRouter) ID() RouterID {
 	return r.routerID
 }
 
@@ -89,9 +93,8 @@ func (r *LangRouter) Chat(ctx context.Context, req *schemas.ChatRequest) (*schem
 
 			resp, err := langModel.Chat(ctx, req)
 			if err != nil {
-				r.tel.L().Warn(
+				r.logger.Warn(
 					"Lang model failed processing chat request",
-					zap.String("routerID", r.ID()),
 					zap.String("modelID", langModel.ID()),
 					zap.String("provider", langModel.Provider()),
 					zap.Error(err),
@@ -107,7 +110,7 @@ func (r *LangRouter) Chat(ctx context.Context, req *schemas.ChatRequest) (*schem
 
 		// no providers were available to handle the request,
 		//  so we have to wait a bit with a hope there is some available next time
-		r.tel.L().Warn("No healthy model found to serve chat request, wait and retry", zap.String("routerID", r.ID()))
+		r.logger.Warn("No healthy model found to serve chat request, wait and retry")
 
 		err := retryIterator.WaitNext(ctx)
 		if err != nil {
@@ -117,7 +120,7 @@ func (r *LangRouter) Chat(ctx context.Context, req *schemas.ChatRequest) (*schem
 	}
 
 	// if we reach this part, then we are in trouble
-	r.tel.L().Error("No model was available to handle chat request", zap.String("routerID", r.ID()))
+	r.logger.Error("No model was available to handle chat request")
 
 	return nil, ErrNoModelAvailable
 }
@@ -125,15 +128,16 @@ func (r *LangRouter) Chat(ctx context.Context, req *schemas.ChatRequest) (*schem
 func (r *LangRouter) ChatStream(
 	ctx context.Context,
 	req *schemas.ChatStreamRequest,
-	respC chan<- *schemas.ChatStreamResult,
+	respC chan<- *schemas.ChatStreamMessage,
 ) {
 	if len(r.chatStreamModels) == 0 {
-		respC <- schemas.NewChatStreamErrorResult(&schemas.ChatStreamError{
-			ID:       req.ID,
-			ErrCode:  "noModels",
-			Message:  ErrNoModels.Error(),
-			Metadata: req.Metadata,
-		})
+		respC <- schemas.NewChatStreamError(
+			req.ID,
+			r.routerID,
+			schemas.NoModelConfigured,
+			ErrNoModels.Error(),
+			req.Metadata,
+		)
 
 		return
 	}
@@ -155,9 +159,8 @@ func (r *LangRouter) ChatStream(
 			langModel := model.(providers.LangModel)
 			modelRespC, err := langModel.ChatStream(ctx, req)
 			if err != nil {
-				r.tel.L().Error(
+				r.logger.Error(
 					"Lang model failed to create streaming chat request",
-					zap.String("routerID", r.ID()),
 					zap.String("modelID", langModel.ID()),
 					zap.String("provider", langModel.Provider()),
 					zap.Error(err),
@@ -169,9 +172,8 @@ func (r *LangRouter) ChatStream(
 			for chunkResult := range modelRespC {
 				err = chunkResult.Error()
 				if err != nil {
-					r.tel.L().Warn(
+					r.logger.Warn(
 						"Lang model failed processing streaming chat request",
-						zap.String("routerID", r.ID()),
 						zap.String("modelID", langModel.ID()),
 						zap.String("provider", langModel.Provider()),
 						zap.Error(err),
@@ -180,21 +182,25 @@ func (r *LangRouter) ChatStream(
 					// It's challenging to hide an error in case of streaming chat as consumer apps
 					//  may have already used all chunks we streamed this far (e.g. showed them to their users like OpenAI UI does),
 					//  so we cannot easily restart that process from scratch
-					respC <- schemas.NewChatStreamErrorResult(&schemas.ChatStreamError{
-						ID:       req.ID,
-						ErrCode:  "modelUnavailable",
-						Message:  err.Error(),
-						Metadata: req.Metadata,
-					})
+					respC <- schemas.NewChatStreamError(
+						req.ID,
+						r.routerID,
+						schemas.ModelUnavailable,
+						err.Error(),
+						req.Metadata,
+					)
 
 					continue NextModel
 				}
 
 				chunk := chunkResult.Chunk()
 
-				chunk.RouterID = r.routerID
-
-				respC <- schemas.NewChatStreamResult(chunk)
+				respC <- schemas.NewChatStreamChunk(
+					req.ID,
+					r.routerID,
+					req.Metadata,
+					chunk,
+				)
 			}
 
 			return
@@ -202,35 +208,34 @@ func (r *LangRouter) ChatStream(
 
 		// no providers were available to handle the request,
 		//  so we have to wait a bit with a hope there is some available next time
-		r.tel.L().Warn(
-			"No healthy model found to serve streaming chat request, wait and retry",
-			zap.String("routerID", r.ID()),
-		)
+		r.logger.Warn("No healthy model found to serve streaming chat request, wait and retry")
 
 		err := retryIterator.WaitNext(ctx)
 		if err != nil {
 			// something has cancelled the context
-			respC <- schemas.NewChatStreamErrorResult(&schemas.ChatStreamError{
-				ID:       req.ID,
-				ErrCode:  "other",
-				Message:  err.Error(),
-				Metadata: req.Metadata,
-			})
+			respC <- schemas.NewChatStreamError(
+				req.ID,
+				r.routerID,
+				schemas.UnknownError,
+				err.Error(),
+				req.Metadata,
+			)
 
 			return
 		}
 	}
 
 	// if we reach this part, then we are in trouble
-	r.tel.L().Error(
-		"No model was available to handle streaming chat request. Try to configure more fallback models to avoid this",
-		zap.String("routerID", r.ID()),
+	r.logger.Error(
+		"No model was available to handle streaming chat request. " +
+			"Try to configure more fallback models to avoid this",
 	)
 
-	respC <- schemas.NewChatStreamErrorResult(&schemas.ChatStreamError{
-		ID:       req.ID,
-		ErrCode:  "allModelsUnavailable",
-		Message:  ErrNoModelAvailable.Error(),
-		Metadata: req.Metadata,
-	})
+	respC <- schemas.NewChatStreamError(
+		req.ID,
+		r.routerID,
+		schemas.AllModelsUnavailable,
+		ErrNoModelAvailable.Error(),
+		req.Metadata,
+	)
 }

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -35,10 +35,14 @@ func NewTelemetry(cfg *Config) (*Telemetry, error) {
 	}, nil
 }
 
+func NewLoggerMock() *zap.Logger {
+	return zap.NewNop()
+}
+
 // NewTelemetryMock returns Telemetry object with NoOp loggers, meters, tracers
 func NewTelemetryMock() *Telemetry {
 	return &Telemetry{
 		Config: DefaultConfig(),
-		Logger: zap.NewNop(),
+		Logger: NewLoggerMock(),
 	}
 }


### PR DESCRIPTION
## Description

## Changes

- Passed RouterID and ModelID information in the chat stream messages
- Introduced a new ChatStreamMessage type that joins both chunk and error messages. Removed unneeded context from provider chatStream structs
- defined a set of possible error codes during chat streaming
- started simplifying logging by using context-based loggers
- Introduced finish_reason on the error schema

## Testing

https://github.com/EinStack/glide/assets/9402690/d09334be-23ac-46dc-a869-dc2e6653976b

