### PR TITLE
Make all durations human-readable when marshalling json/yaml

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -771,7 +771,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "min_delay": {
-                    "type": "integer"
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -762,13 +762,13 @@
                     "type": "integer"
                 },
                 "max_delay": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "max_retries": {
                     "type": "integer"
                 },
                 "min_delay": {
-                    "type": "integer"
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -391,11 +391,11 @@ definitions:
       base_multiplier:
         type: integer
       max_delay:
-        type: integer
+        type: string
       max_retries:
         type: integer
       min_delay:
-        type: integer
+        type: string
     type: object
   routers.LangRouterConfig:
     properties:

--- a/pkg/providers/clients/config.go
+++ b/pkg/providers/clients/config.go
@@ -10,7 +10,7 @@ type ClientConfig struct {
 }
 
 func DefaultClientConfig() *ClientConfig {
-	defaultTimeout := 1000 * time.Second
+	defaultTimeout := 10 * time.Second
 
 	return &ClientConfig{
 		Timeout: &defaultTimeout,

--- a/pkg/providers/clients/config.go
+++ b/pkg/providers/clients/config.go
@@ -1,15 +1,40 @@
 package clients
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 type ClientConfig struct {
 	Timeout *time.Duration `yaml:"timeout,omitempty" json:"timeout" swaggertype:"primitive,string"`
 }
 
 func DefaultClientConfig() *ClientConfig {
-	defaultTimeout := 10 * time.Second
+	defaultTimeout := 1000 * time.Second
 
 	return &ClientConfig{
 		Timeout: &defaultTimeout,
 	}
+}
+
+func (c *ClientConfig) MarshalJSON() ([]byte, error) {
+	type Alias ClientConfig
+	return json.Marshal(&struct {
+		Timeout string `json:"timeout,omitempty"`
+		*Alias
+	}{
+		Timeout: c.Timeout.String(),
+		Alias:   (*Alias)(c),
+	})
+}
+
+func (c *ClientConfig) MarshalYAML() ([]byte, error) {
+	type Alias ClientConfig
+	return json.Marshal(&struct {
+		Timeout string `yaml:"timeout,omitempty"`
+		*Alias
+	}{
+		Timeout: c.Timeout.String(),
+		Alias:   (*Alias)(c),
+	})
 }

--- a/pkg/routers/retry/config.go
+++ b/pkg/routers/retry/config.go
@@ -1,12 +1,15 @@
 package retry
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 type ExpRetryConfig struct {
 	MaxRetries     int            `yaml:"max_retries,omitempty" json:"max_retries"`
 	BaseMultiplier int            `yaml:"base_multiplier,omitempty" json:"base_multiplier"`
-	MinDelay       time.Duration  `yaml:"min_delay,omitempty" json:"min_delay" swaggertype:"primitive,integer"`
-	MaxDelay       *time.Duration `yaml:"max_delay,omitempty" json:"max_delay" swaggertype:"primitive,integer"`
+	MinDelay       time.Duration  `yaml:"min_delay,omitempty" json:"min_delay" swaggertype:"primitive,string"`
+	MaxDelay       *time.Duration `yaml:"max_delay,omitempty" json:"max_delay" swaggertype:"primitive,string"`
 }
 
 func DefaultExpRetryConfig() *ExpRetryConfig {
@@ -18,4 +21,38 @@ func DefaultExpRetryConfig() *ExpRetryConfig {
 		MinDelay:       2 * time.Second,
 		MaxDelay:       &maxDelay,
 	}
+}
+
+func (e *ExpRetryConfig) MarshalJSON() ([]byte, error) {
+	type Alias ExpRetryConfig
+	return json.Marshal(&struct {
+		MinDelay string  `json:"min_delay,omitempty"`
+		MaxDelay *string `json:"max_delay,omitempty"`
+		*Alias
+	}{
+		MinDelay: e.MinDelay.String(),
+		MaxDelay: durationPtrToString(e.MaxDelay),
+		Alias:    (*Alias)(e),
+	})
+}
+
+func (e *ExpRetryConfig) MarshalYAML() (interface{}, error) {
+	type Alias ExpRetryConfig
+	return &struct {
+		MinDelay string  `yaml:"min_delay,omitempty"`
+		MaxDelay *string `yaml:"max_delay,omitempty"`
+		*Alias
+	}{
+		MinDelay: e.MinDelay.String(),
+		MaxDelay: durationPtrToString(e.MaxDelay),
+		Alias:    (*Alias)(e),
+	}, nil
+}
+
+func durationPtrToString(d *time.Duration) *string {
+	if d == nil {
+		return nil
+	}
+	s := d.String()
+	return &s
 }

--- a/pkg/routers/retry/config_test.go
+++ b/pkg/routers/retry/config_test.go
@@ -1,8 +1,11 @@
 package retry
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -10,4 +13,27 @@ func TestRetryConfig_DefaultConfig(t *testing.T) {
 	config := DefaultExpRetryConfig()
 
 	require.NotNil(t, config)
+}
+
+func TestExpRetryConfig_MarshalJSON(t *testing.T) {
+	minDelay := 2 * time.Second
+	maxDelay := 5 * time.Minute
+
+	config := &ExpRetryConfig{
+		MaxRetries:     4,
+		BaseMultiplier: 2,
+		MinDelay:       minDelay,
+		MaxDelay:       &maxDelay,
+	}
+
+	expectedJSON := `{
+		"max_retries": 4,
+		"base_multiplier": 2,
+		"min_delay": "2s",
+		"max_delay": "5m0s"
+	}`
+
+	marshaledJSON, err := json.MarshalIndent(config, "", "\t")
+	assert.NoError(t, err)
+	assert.JSONEq(t, expectedJSON, string(marshaledJSON))
 }


### PR DESCRIPTION
Render all Durations like retry.min_delay, retry.max_delay, client.timeout as human-friendly strings (e.g. 5s) by custom marshalling.

![image](https://github.com/EinStack/glide/assets/1741070/2ed361b5-0f2f-4811-b1d9-7153883c16cc)
