### PR TITLE
🔧 #248 Disable span and metrics by default

### DIFF
--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -131,10 +131,10 @@ type noopSpanExporter struct{}
 
 var _ trace.SpanExporter = noopSpanExporter{}
 
-func (e noopSpanExporter) ExportSpans(ctx context.Context, spans []trace.ReadOnlySpan) error {
+func (e noopSpanExporter) ExportSpans(_ context.Context, _ []trace.ReadOnlySpan) error {
 	return nil
 }
 
-func (e noopSpanExporter) Shutdown(ctx context.Context) error {
+func (e noopSpanExporter) Shutdown(_ context.Context) error {
 	return nil
 }

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -113,7 +113,7 @@ func NewTelemetryMock() *Telemetry {
 
 func newMetricReader() (sdkmetric.Reader, error) {
 	return autoexport.NewMetricReader(context.Background(),
-		autoexport.WithFallbackMetricReader(func(ctx context.Context) (sdkmetric.Reader, error) {
+		autoexport.WithFallbackMetricReader(func(_ context.Context) (sdkmetric.Reader, error) {
 			return metric.NewManualReader(), nil
 		}),
 	)
@@ -121,7 +121,7 @@ func newMetricReader() (sdkmetric.Reader, error) {
 
 func newSpanExporter() (sdktrace.SpanExporter, error) {
 	return autoexport.NewSpanExporter(context.Background(), autoexport.WithFallbackSpanExporter(
-		func(ctx context.Context) (sdktrace.SpanExporter, error) {
+		func(_ context.Context) (sdktrace.SpanExporter, error) {
 			return noopSpanExporter{}, nil
 		},
 	))

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -1,12 +1,32 @@
 package telemetry
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/metric"
 )
 
 func TestTelemetry_Creation(t *testing.T) {
 	_, err := NewTelemetry(DefaultConfig())
 	require.NoError(t, err)
+}
+
+func TestDefaults_noopExporters(t *testing.T) {
+	// By default all otel providers must be noop. Since we don't have otel setup
+	// in test environment, this test ensures all providers are noop.
+	mr, err := newMetricReader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// ensures we have a noop metric.ManualReader
+	mr.(*metric.ManualReader).Shutdown(context.Background())
+
+	se, err := newSpanExporter()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// ensures we have a noopSpanExporter
+	se.(noopSpanExporter).Shutdown(context.Background())
 }

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -21,12 +21,12 @@ func TestDefaults_noopExporters(t *testing.T) {
 		t.Fatal(err)
 	}
 	// ensures we have a noop metric.ManualReader
-	mr.(*metric.ManualReader).Shutdown(context.Background())
+	_ = mr.(*metric.ManualReader).Shutdown(context.Background())
 
 	se, err := newSpanExporter()
 	if err != nil {
 		t.Fatal(err)
 	}
 	// ensures we have a noopSpanExporter
-	se.(noopSpanExporter).Shutdown(context.Background())
+	_ = se.(noopSpanExporter).Shutdown(context.Background())
 }


### PR DESCRIPTION
fixes #248

This commit adds fallback exporters to autoexport. Ensuring spans and metrics are disabled.

A unit test is included to ensure we use the correct exporters.