### PR TITLE
265: unifying roles, setting default as user

### DIFF
--- a/pkg/api/schemas/chat.go
+++ b/pkg/api/schemas/chat.go
@@ -62,7 +62,7 @@ func (r *ChatRequest) Params(modelID string, modelName string) *ChatParams {
 func NewChatFromStr(message string) *ChatRequest {
 	return &ChatRequest{
 		Message: ChatMessage{
-			"user",
+			RoleUser,
 			message,
 		},
 	}
@@ -93,10 +93,18 @@ type TokenUsage struct {
 	TotalTokens    int `json:"total_tokens"`
 }
 
+type Role string
+
+const (
+	RoleSystem    Role = "system"
+	RoleUser      Role = "user"
+	RoleAssistant Role = "assistant"
+)
+
 // ChatMessage is a message in a chat request.
 type ChatMessage struct {
 	// The role of the author of this message. One of system, user, or assistant.
-	Role string `json:"role" validate:"required"`
+	Role Role `json:"role" validate:"required"`
 	// The content of the message.
 	Content string `json:"content" validate:"required"`
 }

--- a/pkg/api/schemas/chat_stream.go
+++ b/pkg/api/schemas/chat_stream.go
@@ -30,7 +30,7 @@ func NewChatStreamFromStr(message string) *ChatStreamRequest {
 	return &ChatStreamRequest{
 		ChatRequest: &ChatRequest{
 			Message: ChatMessage{
-				"user",
+				RoleUser,
 				message,
 			},
 		},

--- a/pkg/api/schemas/chat_test.go
+++ b/pkg/api/schemas/chat_test.go
@@ -30,7 +30,7 @@ func TestChatRequest_DefaultParams(t *testing.T) {
 
 	chatReq := ChatRequest{
 		Message: ChatMessage{
-			Role:    "user",
+			Role:    RoleUser,
 			Content: defaultMessage,
 		},
 		MessageHistory: []ChatMessage{
@@ -42,7 +42,7 @@ func TestChatRequest_DefaultParams(t *testing.T) {
 		OverrideParams: &map[string]ModelParamsOverride{
 			modelID: {
 				Message: ChatMessage{
-					Role:    "user",
+					Role:    RoleUser,
 					Content: myModelMessage,
 				},
 			},
@@ -66,7 +66,7 @@ func TestChatRequest_ModelIDOverride(t *testing.T) {
 
 	chatReq := ChatRequest{
 		Message: ChatMessage{
-			Role:    "user",
+			Role:    RoleUser,
 			Content: defaultMessage,
 		},
 		MessageHistory: []ChatMessage{
@@ -78,7 +78,7 @@ func TestChatRequest_ModelIDOverride(t *testing.T) {
 		OverrideParams: &map[string]ModelParamsOverride{
 			modelID: {
 				Message: ChatMessage{
-					Role:    "user",
+					Role:    RoleUser,
 					Content: myModelMessage,
 				},
 			},
@@ -102,7 +102,7 @@ func TestChatRequest_ModelNameOverride(t *testing.T) {
 
 	chatReq := ChatRequest{
 		Message: ChatMessage{
-			Role:    "user",
+			Role:    RoleUser,
 			Content: defaultMessage,
 		},
 		MessageHistory: []ChatMessage{
@@ -114,7 +114,7 @@ func TestChatRequest_ModelNameOverride(t *testing.T) {
 		OverrideParams: &map[string]ModelParamsOverride{
 			modelName: {
 				Message: ChatMessage{
-					Role:    "user",
+					Role:    RoleUser,
 					Content: myModelMessage,
 				},
 			},
@@ -139,7 +139,7 @@ func TestChatRequest_ModelNameIDOverride(t *testing.T) {
 
 	chatReq := ChatRequest{
 		Message: ChatMessage{
-			Role:    "user",
+			Role:    RoleUser,
 			Content: defaultMessage,
 		},
 		MessageHistory: []ChatMessage{
@@ -151,13 +151,13 @@ func TestChatRequest_ModelNameIDOverride(t *testing.T) {
 		OverrideParams: &map[string]ModelParamsOverride{
 			modelName: {
 				Message: ChatMessage{
-					Role:    "user",
+					Role:    RoleUser,
 					Content: myModelNameMessage,
 				},
 			},
 			modelID: {
 				Message: ChatMessage{
-					Role:    "user",
+					Role:    RoleUser,
 					Content: myModelIDMessage,
 				},
 			},

--- a/pkg/providers/anthropic/chat.go
+++ b/pkg/providers/anthropic/chat.go
@@ -139,7 +139,7 @@ func (c *Client) doChatRequest(ctx context.Context, payload *ChatRequest) (*sche
 		ModelResponse: schemas.ModelResponse{
 			Metadata: map[string]string{},
 			Message: schemas.ChatMessage{
-				Role:    completion.Type,
+				Role:    schemas.Role(completion.Type),
 				Content: completion.Text,
 			},
 			TokenUsage: schemas.TokenUsage{

--- a/pkg/providers/azureopenai/chat_stream_test.go
+++ b/pkg/providers/azureopenai/chat_stream_test.go
@@ -72,7 +72,7 @@ func TestAzureOpenAIClient_ChatStreamRequest(t *testing.T) {
 			require.NoError(t, err)
 
 			chatParams := schemas.ChatParams{Messages: []schemas.ChatMessage{{
-				Role:    "user",
+				Role:    schemas.RoleUser,
 				Content: "What's the capital of the United Kingdom?",
 			}}}
 
@@ -140,7 +140,7 @@ func TestAzureOpenAIClient_ChatStreamRequestInterrupted(t *testing.T) {
 			require.NoError(t, err)
 
 			chatParams := schemas.ChatParams{Messages: []schemas.ChatMessage{{
-				Role:    "user",
+				Role:    schemas.RoleUser,
 				Content: "What's the biggest animal?",
 			}}}
 

--- a/pkg/providers/azureopenai/client_test.go
+++ b/pkg/providers/azureopenai/client_test.go
@@ -56,7 +56,7 @@ func TestAzureOpenAIClient_ChatRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	chatParams := schemas.ChatParams{Messages: []schemas.ChatMessage{{
-		Role:    "user",
+		Role:    schemas.RoleUser,
 		Content: "What's the capital of the United Kingdom?",
 	}}}
 
@@ -116,7 +116,7 @@ func TestDoChatRequest_ErrorResponse(t *testing.T) {
 	require.NoError(t, err)
 
 	chatParams := schemas.ChatParams{Messages: []schemas.ChatMessage{{
-		Role:    "user",
+		Role:    schemas.RoleUser,
 		Content: "What's the dealio?",
 	}}}
 

--- a/pkg/providers/bedrock/client_test.go
+++ b/pkg/providers/bedrock/client_test.go
@@ -62,7 +62,7 @@ func TestBedrockClient_ChatRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	chatParams := schemas.ChatParams{Messages: []schemas.ChatMessage{{
-		Role:    "user",
+		Role:    schemas.RoleUser,
 		Content: "What's the biggest animal?",
 	}}}
 

--- a/pkg/providers/bedrock/testdata/chat.req.json
+++ b/pkg/providers/bedrock/testdata/chat.req.json
@@ -2,7 +2,7 @@
   "model": "amazon.titan-text-express-v1",
   "messages": [
     {
-      "role": "user",
+      "role": schemas.RoleUser,
       "content": "What's the biggest animal?"
     }
   ],

--- a/pkg/providers/octoml/client_test.go
+++ b/pkg/providers/octoml/client_test.go
@@ -121,7 +121,7 @@ func TestDoChatRequest_ErrorResponse(t *testing.T) {
 
 	// Create a chat request payload
 	chatParams := schemas.ChatParams{Messages: []schemas.ChatMessage{{
-		Role:    "user",
+		Role:    schemas.RoleUser,
 		Content: "What's the dealeo?",
 	}}}
 

--- a/pkg/providers/ollama/chat.go
+++ b/pkg/providers/ollama/chat.go
@@ -172,7 +172,7 @@ func (c *Client) doChatRequest(ctx context.Context, payload *ChatRequest) (*sche
 		Cached:    false,
 		ModelResponse: schemas.ModelResponse{
 			Message: schemas.ChatMessage{
-				Role:    ollamaCompletion.Message.Role,
+				Role:    schemas.Role(ollamaCompletion.Message.Role),
 				Content: ollamaCompletion.Message.Content,
 			},
 			TokenUsage: schemas.TokenUsage{

--- a/pkg/providers/ollama/client_test.go
+++ b/pkg/providers/ollama/client_test.go
@@ -57,7 +57,7 @@ func TestOllamaClient_ChatRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	chatParams := schemas.ChatParams{Messages: []schemas.ChatMessage{{
-		Role:    "user",
+		Role:    schemas.RoleUser,
 		Content: "What's the biggest animal?",
 	}}}
 
@@ -85,7 +85,7 @@ func TestOllamaClient_ChatRequest_Non200Response(t *testing.T) {
 	require.NoError(t, err)
 
 	chatParams := schemas.ChatParams{Messages: []schemas.ChatMessage{{
-		Role:    "user",
+		Role:    schemas.RoleUser,
 		Content: "What's the capital of the United Kingdom?",
 	}}}
 
@@ -122,7 +122,7 @@ func TestOllamaClient_ChatRequest_SuccessfulResponse(t *testing.T) {
 	require.NoError(t, err)
 
 	chatParams := schemas.ChatParams{Messages: []schemas.ChatMessage{{
-		Role:    "user",
+		Role:    schemas.RoleUser,
 		Content: "What's the capital of the United Kingdom?",
 	}}}
 

--- a/pkg/providers/openai/chat_stream_test.go
+++ b/pkg/providers/openai/chat_stream_test.go
@@ -72,7 +72,7 @@ func TestOpenAIClient_ChatStreamRequest(t *testing.T) {
 			require.NoError(t, err)
 
 			chatParams := schemas.ChatParams{Messages: []schemas.ChatMessage{{
-				Role:    "user",
+				Role:    schemas.RoleUser,
 				Content: "What's the capital of the United Kingdom?",
 			}}}
 
@@ -140,7 +140,7 @@ func TestOpenAIClient_ChatStreamRequestInterrupted(t *testing.T) {
 			require.NoError(t, err)
 
 			chatParams := schemas.ChatParams{Messages: []schemas.ChatMessage{{
-				Role:    "user",
+				Role:    schemas.RoleUser,
 				Content: "What's the capital of the United Kingdom?",
 			}}}
 

--- a/pkg/providers/openai/chat_test.go
+++ b/pkg/providers/openai/chat_test.go
@@ -57,7 +57,7 @@ func TestOpenAIClient_ChatRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	chatParams := schemas.ChatParams{Messages: []schemas.ChatMessage{{
-		Role:    "user",
+		Role:    schemas.RoleUser,
 		Content: "What's the capital of the United Kingdom?",
 	}}}
 


### PR DESCRIPTION
Adding specific roles and setting the default to `user` when a new chat is started.

Closes #265 